### PR TITLE
change altz to z in :coordinates attribute

### DIFF
--- a/apph.adoc
+++ b/apph.adoc
@@ -453,19 +453,19 @@ If the profile instances have the same number of elements and the vertical coord
           pressure:standard_name = "air_pressure" ;
           pressure:long_name = "pressure level" ;
           pressure:units = "hPa" ;
-          pressure:coordinates = "time lon lat altz" ;
+          pressure:coordinates = "time lon lat z" ;
 
       float temperature(profile, z) ; 
           temperature:standard_name = "surface_temperature" ;
           temperature:long_name = "skin temperature" ;
           temperature:units = "Celsius" ;
-          temperature:coordinates = "time lon lat altz" ;
+          temperature:coordinates = "time lon lat z" ;
 
       float humidity(profile, z) ; 
           humidity:standard_name = "relative_humidity" ;
           humidity:long_name = "relative humidity" ;
           humidity:units = "%" ;
-          humidity:coordinates = "time lon lat altz" ;
+          humidity:coordinates = "time lon lat z" ;
 
    attributes:
       :featureType = "profile";


### PR DESCRIPTION
coordinates attribute refers to an undefined variable altz, which doesn't exist as a variable or anything else, afaict, but z does.
