### PR TITLE
Fix link title for appendix H

### DIFF
--- a/apph.adoc
+++ b/apph.adoc
@@ -1,5 +1,5 @@
 
-[[appendix-examples-discrete-geometries]]
+[[appendix-examples-discrete-geometries, Appendix H, Annotated Examples of Discrete Geometries]]
 
 [appendix]
 == Annotated Examples of Discrete Geometries


### PR DESCRIPTION
A follow-up to #72, which fixes the link title shown for cross-references to Appendix H.

Currently a cross-reference to appendix H shows as:

> "In _Annotated Examples of Discrete Geometries_, updated ... "

but this PR changes it to bring it in line with all the other appendices:

> "In _Appendix H, Annotated Examples of Discrete Geometries_, updated ... "