### PR TITLE
Changes required by ticket #75

### DIFF
--- a/appf.adoc
+++ b/appf.adoc
@@ -135,6 +135,9 @@ __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates
 __Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at link:$$http://proj4.org/projections/lcc.html$$[http://proj4.org/projections/lcc.html].
 and
 link:$$http://geotiff.maptools.org/proj_list/lambert_conic_conformal_1sp.html$$[http://geotiff.maptools.org/proj_list/lambert_conic_conformal_1sp.html]
+("Lambert Conic Conformal (1SP)" or EPSG 9801) or
+link:$$http://geotiff.maptools.org/proj_list/lambert_conic_conformal_2sp.html$$[http://geotiff.maptools.org/proj_list/lambert_conic_conformal_2sp.html]
+ ("Lambert Conic Conformal (2SP)" or EPSG 9802). For the 1SP variant, latitude_of_projection_origin=standard_parallel and the PROJ.4 scale factor is 1.
 
 === Lambert Cylindrical Equal Area
 

--- a/appf.adoc
+++ b/appf.adoc
@@ -36,7 +36,8 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at link:$$http://www.remotesensing.org/geotiff/proj_list/albers_equal_area_conic.html$$[http://www.remotesensing.org/geotiff/proj_list/albers_equal_area_conic.html].
+__Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at
+link:$$http://geotiff.maptools.org/proj_list/albers_equal_area_conic.html$$[http://geotiff.maptools.org/proj_list/albers_equal_area_conic.html].
 
 
 [[azimuthal-equidistant]]
@@ -56,8 +57,10 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at link:$$http://www.remotesensing.org/geotiff/proj_list/azimuthal_equidistant.html$$[http://www.remotesensing.org/geotiff/proj_list/azimuthal_equidistant.html].
-
+__Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at
+link:$$http://geotiff.maptools.org/proj_list/azimuthal_equidistant.html$$[http://geotiff.maptools.org/proj_list/azimuthal_equidistant.html]
+and
+link:$$http://proj4.org/projections/aeqd.html$$[http://proj4.org/projections/aeqd.html].
 
 === Geostationary projection
 
@@ -106,7 +109,10 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at link:$$http://www.remotesensing.org/geotiff/proj_list/lambert_azimuthal_equal_area.html$$[http://www.remotesensing.org/geotiff/proj_list/lambert_azimuthal_equal_area.html].
+__Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at
+link:$$http://proj4.org/projections/laea.html$$[http://proj4.org/projections/laea.html]
+and
+link:$$http://geotiff.maptools.org/proj_list/lambert_azimuthal_equal_area.html$$[http://geotiff.maptools.org/proj_list/lambert_azimuthal_equal_area.html]
 
 
 === Lambert conformal
@@ -126,8 +132,9 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at link:$$http://proj4.org/projections$$[http://proj4.org/projections].
-
+__Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at link:$$http://proj4.org/projections/lcc.html$$[http://proj4.org/projections/lcc.html].
+and
+link:$$http://geotiff.maptools.org/proj_list/lambert_conic_conformal_1sp.html$$[http://geotiff.maptools.org/proj_list/lambert_conic_conformal_1sp.html]
 
 === Lambert Cylindrical Equal Area
 
@@ -145,7 +152,9 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute value **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Notes on using the PROJ.4 software packages for computing the mapping may be found at link:$$http://www.remotesensing.org/geotiff/proj_list/cylindrical_equal_area.html$$[http://www.remotesensing.org/geotiff/proj_list/cylindrical_equal_area.html] ("Lambert Cylindrical Equal Area" or EPSG 9834 or EPSG 9835). Detailed formulas can be found in <<bibliography.adoc#Snyder>> pages 76-85.
+__Notes:__:: Notes on using the PROJ.4 software packages for computing the mapping may be found at
+link:$$http://geotiff.maptools.org/proj_list/cylindrical_equal_area.html$$[http://geotiff.maptools.org/proj_list/cylindrical_equal_area.html]
+("Lambert Cylindrical Equal Area" or EPSG 9834 or EPSG 9835). Detailed formulas can be found in <<bibliography.adoc#Snyder>> pages 76-85.
 
 
 === Latitude-Longitude
@@ -181,7 +190,14 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute value **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Notes on using the PROJ.4 software packages for computing the mapping may be found at link:$$http://www.remotesensing.org/geotiff/proj_list/mercator_1sp.html$$[http://www.remotesensing.org/geotiff/proj_list/mercator_1sp.html] ("Mercator (1SP)" or EPSG 9804) or link:$$http://www.remotesensing.org/geotiff/proj_list/mercator_2sp.html$$[http://www.remotesensing.org/geotiff/proj_list/mercator_2sp.html] ("Mercator (2SP)" or EPSG 9805).
+__Notes:__:: Notes on using the PROJ.4 software packages for computing the mapping may be found at
+link:$$http://proj4.org/projections/merc.html$$[http://proj4.org/projections/merc.html]
+and
+link:$$http://geotiff.maptools.org/proj_list/mercator_1sp.html$$[http://geotiff.maptools.org/proj_list/mercator_1sp.html]
+("Mercator (1SP)" or EPSG 9804)
+or
+link:$$http://geotiff.maptools.org/proj_list/mercator_2sp.html$$[http://geotiff.maptools.org/proj_list/mercator_2sp.html]
+("Mercator (2SP)" or EPSG 9805).
           
 +
 More information on formulas available in <<OGP-EPSG_GN7_2>>.
@@ -205,7 +221,11 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at link:$$http://www.remotesensing.org/geotiff/proj_list/oblique_mercator.html$$[http://www.remotesensing.org/geotiff/proj_list/ oblique_mercator.html]. The Rotated Mercator projection is an Oblique Mercator projection with azimuth = +90.
+__Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at
+link:$$http://proj4.org/projections/omerc.html$$[http://proj4.org/projections/omerc.html]
+and
+link:$$http://geotiff.maptools.org/proj_list/oblique_mercator.html$$[http://geotiff.maptools.org/proj_list/oblique_mercator.html].
+The Rotated Mercator projection is an Oblique Mercator projection with azimuth = +90.
 
 
 === Orthographic
@@ -224,7 +244,11 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute value **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Notes on using the PROJ.4 software packages for computing the mapping may be found at link:$$http://www.remotesensing.org/geotiff/proj_list/orthographic.html$$[http://www.remotesensing.org/geotiff/proj_list/orthographic.html] ("Orthographic" or EPSG 9840).
+__Notes:__:: Notes on using the PROJ.4 software packages for computing the mapping may be found at
+link:$$http://proj4.org/projections/ortho.html$$[http://proj4.org/projections/ortho.html]
+and
+link:$$http://geotiff.maptools.org/proj_list/orthographic.html$$[http://geotiff.maptools.org/proj_list/orthographic.html]
+("Orthographic" or EPSG 9840).
           
 +
 More information on formulas available in <<OGP-EPSG_GN7_2>>.
@@ -249,7 +273,7 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at link:$$http://www.remotesensing.org/geotiff/proj_list/polar_stereographic.html$$[http://www.remotesensing.org/geotiff/proj_list/polar_stereographic.html].
+__Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at link:$$http://geotiff.maptools.org/proj_list/polar_stereographic.html$$[http://geotiff.maptools.org/proj_list/polar_stereographic.html]
 
 The standard_parallel variant corresponds to EPSG Polar Stereographic (Variant B) (EPSG dataset coordinate operation method code 9829),
 while the scale_factor_at_projection_origin variant corresponds to EPSG Polar Stereographic (Variant A)
@@ -290,7 +314,11 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at link:$$http://www.remotesensing.org/geotiff/proj_list/sinusoidal.html$$[http://www.remotesensing.org/geotiff/proj_list/sinusoidal.html]. Detailed formulas can be found in <<Snyder>>, pages 243-248.
+__Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at
+link:$$http://proj4.org/projections/sinu.html$$[http://proj4.org/projections/sinu.html]
+and
+link:$$http://geotiff.maptools.org/proj_list/sinusoidal.html$$[http://geotiff.maptools.org/proj_list/sinusoidal.html].
+Detailed formulas can be found in <<Snyder>>, pages 243-248.
 
 
 === Stereographic
@@ -310,7 +338,11 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Formulas for the mapping and its inverse along with notes on using the **`PROJ.4`** software package for doing the calcuations may be found at link:$$http://www.remotesensing.org/geotiff/proj_list/stereographic.html$$[http://www.remotesensing.org/geotiff/proj_list/stereographic.html] . See the section "Polar stereographic" for the special case when the projection origin is one of the poles.
+__Notes:__:: Formulas for the mapping and its inverse along with notes on using the **`PROJ.4`** software package for doing the calcuations may be found at
+link:$$http://proj4.org/projections/stere.html$$[http://proj4.org/projections/stere.html]
+and
+link:$$http://geotiff.maptools.org/proj_list/stereographic.html$$[http://geotiff.maptools.org/proj_list/stereographic.html].
+See the section "Polar stereographic" for the special case when the projection origin is one of the poles.
 
 
 === Transverse Mercator
@@ -330,7 +362,10 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Formulas for the mapping and its inverse along with notes on using the **`PROJ.4`** software package for doing the calcuations may be found at link:$$http://www.remotesensing.org/geotiff/proj_list/transverse_mercator.html$$[http://www.remotesensing.org/geotiff/proj_list/transverse_mercator.html].
+__Notes:__:: Formulas for the mapping and its inverse along with notes on using the **`PROJ.4`** software package for doing the calcuations may be found at
+link:$$http://proj4.org/projections/tmerc.html$$[http://proj4.org/projections/tmerc.html]
+and
+link:$$http://geotiff.maptools.org/proj_list/transverse_mercator.html$$[http://geotiff.maptools.org/proj_list/transverse_mercator.html].
 
 
 [[vertical-perspective]]

--- a/appf.adoc
+++ b/appf.adoc
@@ -126,7 +126,7 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at link:$$http://www.remotesensing.org/geotiff/proj_list/lambert_conic_conformal_2sp.html$$[http://www.remotesensing.org/geotiff/proj_list/lambert_conic_conformal_2sp.html].
+__Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at link:$$http://proj4.org/projections$$[http://proj4.org/projections].
 
 
 === Lambert Cylindrical Equal Area
@@ -139,7 +139,7 @@ grid_mapping_name = lambert_cylindrical_equal_area
 
 __Map parameters:__::
 * **`longitude_of_central_meridian`**
-* Either **`standard_parallel`** or **`scale_factor_at_projection_origin`**
+* Either **`standard_parallel`** or **`scale_factor_at_projection_origin`** (deprecated)
 * **`false_easting`**
 * **`false_northing`**
 
@@ -243,7 +243,7 @@ grid_mapping_name = polar_stereographic
 __Map parameters:__::
 * **`straight_vertical_longitude_from_pole`**
 * **`latitude_of_projection_origin`** - Either +90. or -90.
-* Either **`standard_parallel`** or **`scale_factor_at_projection_origin`**
+* Either **`standard_parallel`** (EPSG 9829) or **`scale_factor_at_projection_origin`** (EPSG 9810)
 * **`false_easting`**
 * **`false_northing`**
 
@@ -251,6 +251,10 @@ __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates
 
 __Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at link:$$http://www.remotesensing.org/geotiff/proj_list/polar_stereographic.html$$[http://www.remotesensing.org/geotiff/proj_list/polar_stereographic.html].
 
+The standard_parallel variant corresponds to EPSG Polar Stereographic (Variant B) (EPSG dataset coordinate operation method code 9829),
+while the scale_factor_at_projection_origin variant corresponds to EPSG Polar Stereographic (Variant A)
+(EPSG dataset coordinate operation method code 9810).
+As PROJ.4 requires the standard parallel, [Snyder] formula 21-7 can be used to compute it from the scale factor if needed.
 
 === Rotated pole
 

--- a/history.adoc
+++ b/history.adoc
@@ -119,3 +119,6 @@ mean_absolute_value to cell methods in Appendix E
 . Ticket #87, Allow comments in coordinate variables
 . Ticket #92, Add oblique mercator projection
 . Ticket #72, Adding the geostationary projection.
+
+.?? February 2017
+. Ticket #75, fix documentation and definitions of 3 grid mapping definitions


### PR DESCRIPTION
This has the changes specified in ticket 75, except for the urls and related text.
Please do not merge this pull request until we have correct urls, and surrounding text.

The ticket's urls are now invalid.  For lambert_conformal_conic, I replaced the two urls with a more generic reference to http://proj4.org/projections.  For polar_stereographic, I have made no replacement.  Proj4.org lists "universal polar stereographic" which I think might be slightly different from "polar stereographic"; I need more advice here.

For all grid mappings, the grid-mapping-specific text at proj4.org is extremely terse, briefer than the references to it in Appendix F!