### PR TITLE
#74

### DIFF
--- a/appc.adoc
+++ b/appc.adoc
@@ -17,7 +17,8 @@ In the __Units__ column, __u__ indicates units dimensionally equivalent to those
 
 | `number_of_observations` | 1
 | The number of discrete observations or measurements from which a data
-value has been derived.
+value has been derived. The use of this modifier is deprecated and the standard_name 
+number_of_observations is preferred to describe this type of metadata variable. 
 
 | `standard_error` | __u__
 | The uncertainty of the data value. The standard error includes both
@@ -31,5 +32,6 @@ ancillary variable should have an attribute
 | Flag values indicating the quality or other status of the data values.
 The variable should have **`flag_values`** or **`flag_masks`** (or both)
 and **`flag_meanings`** attributes to show how it should be interpreted
-(<<flags>>).
+(<<flags>>). The use of this modifier is deprecated and the standard_name status_flag is 
+preferred to describe this type of metadata variable.
 |===============

--- a/ch03.adoc
+++ b/ch03.adoc
@@ -162,13 +162,16 @@ enumerated status code.
 ----
   byte current_speed_qc(time, depth, lat, lon) ;
     current_speed_qc:long_name = "Current Speed Quality" ;
-    current_speed_qc:standard_name = "sea_water_speed status_flag" ;
+    current_speed_qc:standard_name = "status_flag" ;
     current_speed_qc:_FillValue = -128b ;
     current_speed_qc:valid_range = 0b, 2b ;
     current_speed_qc:flag_values = 0b, 1b, 2b ;
     current_speed_qc:flag_meanings = "quality_good sensor_nonfunctional 
                                       outside_valid_range" ;
 ----
+
+Note that the data variable containing current speed has an ancillary_variables 
+attribute with a value containing current_speed_qc.
 
 
 ====

--- a/history.adoc
+++ b/history.adoc
@@ -122,3 +122,8 @@ mean_absolute_value to cell methods in Appendix E
 
 . 16 February 2017
 . Ticket #103, Corrections to Appendices A and H, finish the ticket with remaining changes to Appendix H.
+
+.21 February 2017 
+. Ticket #74, Removed "sea_water_speed" from flag values example and added Note at 
+bottom of Example 3.3 in Chapter 3.  Also added a sentence to Appendix C Standard Name 
+Modifiers "number of observations" and and a sentence to "status_flag_modifiers"


### PR DESCRIPTION
#74 Removed "sea_water_speed" from flag values example and added Note at 
bottom of Example 3.3 in Chapter 3.  Also added a sentence to Appendix C Standard Name
Modifiers "number of observations" and and a sentence to "status_flag_modifiers"