### PR TITLE
Updated links and references to NUG

### DIFF
--- a/appa.adoc
+++ b/appa.adoc
@@ -28,7 +28,7 @@ Attribute
 | **`add_offset`**
 | N
 | C, D
-| link:$$http://www.unidata.ucar.edu/netcdf/docs/netcdf.html#Attribute-Conventions$$[NUG appendix B], <<packed-data>>
+| link:$$http://www.unidata.ucar.edu/software/netcdf/docs/attribute_conventions.html$$[NUG Appendix A, "Attribute Conventions"], and <<packed-data>>
 | If present for a variable, this number is to be added to the data after it is read by an application.  If both **`scale_factor`** and **`add_offset`** attributes are present, the data are first scaled before the offset is added.  In cases where there is a strong constraint on dataset size, it is allowed to pack the coordinate variables (using add_offset and/or scale_factor), but this is not recommended in general.
 
 | **`ancillary_variables`**
@@ -102,7 +102,7 @@ formula in the definition.
 | **`Conventions`**
 | S
 | G
-| link:$$http://www.unidata.ucar.edu/netcdf/docs/netcdf.html#Attribute-Conventions$$[NUG appendix B]
+| link:$$http://www.unidata.ucar.edu/software/netcdf/docs/attribute_conventions.html$$[NUG Appendix A, "Attribute Conventions"]
 | Name of the conventions followed by the dataset.
 
 | **`coordinates`**
@@ -122,8 +122,8 @@ formula in the definition.
 | **`_FillValue`**
 | D
 | C, D
-| link:$$http://www.unidata.ucar.edu/netcdf/docs/netcdf.html#Attribute-Conventions$$[NUG appendix B],
-  <<missing-data>>, <<ch9-missing-data>>
+| link:$$http://www.unidata.ucar.edu/software/netcdf/docs/attribute_conventions.html$$[NUG Appendix A, "Attribute Conventions"], and
+  <<missing-data>>, and <<ch9-missing-data>>
 | A value used to represent missing or undefined data.  Allowed for auxiliary coordinate variables but not allowed for coordinate variables.
 
 | **`featureType`**
@@ -165,7 +165,7 @@ formula in the definition.
 | **`history`**
 | S
 | G
-| link:$$http://www.unidata.ucar.edu/netcdf/docs/netcdf.html#Attribute-Conventions$$[NUG appendix B]
+| link:$$http://www.unidata.ucar.edu/software/netcdf/docs/attribute_conventions.html$$[NUG Appendix A, "Attribute Conventions"]
 | List of the applications that have modified the original data.
 
 | **`instance_dimension`**
@@ -195,14 +195,14 @@ formula in the definition.
 | **`long_name`**
 | S
 | C, D
-| link:$$http://www.unidata.ucar.edu/netcdf/docs/netcdf.html#Attribute-Conventions$$[NUG appendix B], <<long-name>>
+| link:$$http://www.unidata.ucar.edu/software/netcdf/docs/attribute_conventions.html$$[NUG Appendix A, "Attribute Conventions"], and <<long-name>>
 | A descriptive name that indicates a variable"s content. This name is not standardized.
 
 
 | **`missing_value`**
 | D
 | C, D
-| <<missing-data>>, <<ch9-missing-data>>
+| <<missing-data>>, and <<ch9-missing-data>>
 | A value or values used to represent missing or undefined data.  Allowed for auxiliary coordinate variables but not allowed for coordinate variables.
 
 | **`month_lengths`**
@@ -232,7 +232,7 @@ formula in the definition.
 | **`scale_factor`**
 | N
 | C, D
-| link:$$http://www.unidata.ucar.edu/netcdf/docs/netcdf.html#Attribute-Conventions$$[NUG appendix B], <<packed-data>>
+| link:$$http://www.unidata.ucar.edu/software/netcdf/docs/attribute_conventions.html$$[NUG Appendix A, "Attribute Conventions"], and <<packed-data>>
 | If present for a variable, the data are to be multiplied by this factor after the data are read by an application.  See also the **`add_offset`** attribute.  In cases where there is a strong constraint on dataset size, it is allowed to pack the coordinate variables (using add_offset and/or scale_factor), but this is not recommended in general.
 
 | **`source`**
@@ -256,31 +256,31 @@ formula in the definition.
 | **`title`**
 | S
 | G
-| link:$$http://www.unidata.ucar.edu/netcdf/docs/netcdf.html#Attribute-Conventions$$[NUG appendix B]
+| link:$$http://www.unidata.ucar.edu/software/netcdf/docs/attribute_conventions.html$$[NUG Appendix A, "Attribute Conventions"]
 | Short description of the file contents.
 
 | **`units`**
 | S
 | C, D
-| link:$$http://www.unidata.ucar.edu/netcdf/docs/netcdf.html#Attribute-Conventions$$[NUG appendix B], <<units>>
+| link:$$http://www.unidata.ucar.edu/software/netcdf/docs/attribute_conventions.html$$[NUG Appendix A, "Attribute Conventions"], and <<units>>
 | Units of a variable"s content.
 
 | **`valid_max`**
 | N
 | C, D
-| link:$$http://www.unidata.ucar.edu/netcdf/docs/netcdf.html#Attribute-Conventions$$[NUG appendix B]
+| link:$$http://www.unidata.ucar.edu/software/netcdf/docs/attribute_conventions.html$$[NUG Appendix A, "Attribute Conventions"]
 | Largest valid value of a variable.
 
 | **`valid_min`**
 | N
 | C, D
-| link:$$http://www.unidata.ucar.edu/netcdf/docs/netcdf.html#Attribute-Conventions$$[NUG appendix B]
+| link:$$http://www.unidata.ucar.edu/software/netcdf/docs/attribute_conventions.html$$[NUG Appendix A, "Attribute Conventions"]
 | Smallest valid value of a variable.
 
 | **`valid_range`**
 | N
 | C, D
-| link:$$http://www.unidata.ucar.edu/netcdf/docs/netcdf.html#Attribute-Conventions$$[NUG appendix B]
+| link:$$http://www.unidata.ucar.edu/software/netcdf/docs/attribute_conventions.html$$[NUG Appendix A, "Attribute Conventions"]
 | Smallest and largest valid values of a variable.
 |===============
 

--- a/bibliography.adoc
+++ b/bibliography.adoc
@@ -3,7 +3,7 @@
 
 === References
 
-- [[[COARDS]]]  link:$$http://ferret.wrc.noaa.gov/noaa_coop/coop_cdf_profile.html$$[ Conventions for the standardization of NetCDF Files ] .
+- [[[COARDS]]]  link:$$http://www.ferret.noaa.gov/noaa_coop/coop_cdf_profile.html$$[ Conventions for the standardization of NetCDF Files ] .
 					Sponsored by the "Cooperative
 					Ocean/Atmosphere Research Data
 					Service," a NOAA/university
@@ -17,13 +17,13 @@
 - [[[NetCDF]]]  link:$$http://www.unidata.ucar.edu/netcdf/index.html$$[ NetCDF Software Package] .
 				UNIDATA Program Center of the University Corporation for Atmospheric Research
 			. 
-- [[[NUG]]]  link:$$http://www.unidata.ucar.edu/netcdf/docs/netcdf.html$$[ NetCDF User's Guide for Fortran:  An Access Interface for Self-Describing Portable Data; version 3 ] . Russ Rew, Glenn Davis, Steve Emmerson, and Harvey Davies. June 1997.
+- [[[NUG]]]  link:$$http://www.unidata.ucar.edu/software/netcdf/docs/user_guide.html$$[The NetCDF User's Guide] for NetCDF version 4.4.1.1.
 - [[[OGC_CTS]]]  link:$$http://www.opengeospatial.org/standards/ct$$[ OpenGIS Coordinate Transformation Service Implementation Specification] .  OGC document 01-009. 12 January 2001. 
 - [[[OGP-EPSG]]]  link:$$http://www.epsg.org$$[OGP Surveying &amp; Positioning Committee] and link:$$http://www.epsg-registry.org$$[EPSG Geodetic Parameter Registry] .
 - [[[OGP-EPSG_GN7_2]]]  link:$$http://www.epsg.org$$[OGP Surveying and Positioning Guidance Note 7, part 2: Coordinate Conversions and Transformations including Formulas] .
 - [[[SCH02]]] C Schaer, D Leuenberger, and O Fuhrer. 2002. {ldquo} A new terrain-following vertical coordiante formulation for atmospheric prediction models {rdquo}. __ Monthly Weather Review __.  130 . 2459-2480.
 - [[[Snyder]]]  link:$$http://pubs.er.usgs.gov/usgspubs/pp/pp1395$$[ Map Projections: A Working Manual ] . USGS Professional Paper 1395.
-- [[[UDUNITS]]]  link:$$http://www.unidata.ucar.edu/packages/udunits/$$[ UDUNITS Software Package ] .
+- [[[UDUNITS]]]  link:$$http://www.unidata.ucar.edu/software/udunits/$$[ UDUNITS Software Package ] .
 				UNIDATA Program Center of the University Corporation for Atmospheric Research .
 - [[[W3C]]]  link:$$http://www.w3.org/$$[World Wide Web Consortium (W3C)] .
 - [[[XML]]]  link:$$http://www.w3.org/TR/1998/REC-xml-19980210$$[ Extensible Markup Language (XML) 1.0 ] . T. Bray, J. Paoli, and C.M. Sperberg-McQueen.  10 February 1998 .

--- a/ch01.adoc
+++ b/ch01.adoc
@@ -35,13 +35,14 @@ in multidimensional arrays, when indexing over the elements of the
 array, it is the last declared dimension that is the fastest varying
 in terms of file storage order. The netCDF utilities ncdump and ncgen
 use this format (see   
-link:$$http://www.unidata.ucar.edu/netcdf/docs/netcdf.html#NetCDF-Utilities$$[chapter 5 of the NUG]). All examples in this document
-use CDL syntax.
+link:$$http://www.unidata.ucar.edu/software/netcdf/docs/netcdf_utilities_guide.html#cdl_syntax$$[NUG section on CDL syntax]).
+All examples in this document use CDL syntax.
 
 cell:: A region in one or more dimensions whose boundary can be described by a set of vertices. The term __interval__ is sometimes used for one-dimensional cells.
 
-coordinate variable:: We use this term precisely as it is defined in section   
-link:$$http://www.unidata.ucar.edu/netcdf/docs/netcdf.html#Variables$$[ 2.3.1 of the NUG ] . It is a one-dimensional variable with the same name as its dimension [e.g., **`time(time)`** ], and it is defined as a numeric data type with values that are ordered monotonically. Missing values are not allowed in coordinate variables.
+coordinate variable:: We use this term precisely as it is defined in the
+link:$$http://www.unidata.ucar.edu/software/netcdf/docs/netcdf_data_set_components.html#coordinate_variables$$[NUG section on coordinate variables].
+It is a one-dimensional variable with the same name as its dimension [e.g., **`time(time)`** ], and it is defined as a numeric data type with values that are ordered monotonically. Missing values are not allowed in coordinate variables.
 
 grid mapping variable:: A variable used as a container for attributes that define a specific grid mapping. The type of the variable is arbitrary since it contains no data.
 

--- a/ch02.adoc
+++ b/ch02.adoc
@@ -56,8 +56,8 @@ NetCDF variables that contain coordinate data are referred to as __coordinate va
 ==== Missing data, valid and actual range of data
 
 The NUG conventions
-(link:$$http://www.unidata.ucar.edu/netcdf/docs/netcdf.html#Attribute-Conventions$$[NUG
-appendix B]) provide the **`_FillValue`**, **`missing_value`**,
+(link:$$http://www.unidata.ucar.edu/software/netcdf/docs/attribute_conventions.html$$[NUG Appendix A, Attribute Conventions])
+provide the **`_FillValue`**, **`missing_value`**,
 **`valid_min`**, **`valid_max`**, and **`valid_range`** attributes to indicate
 missing data. Missing data is allowed in data variables and auxiliary coordinate variables. 
 Generic applications should treat the data as missing where any auxiliary coordinate variables 
@@ -73,8 +73,7 @@ that indicates undefined or missing data, and is returned when reading values
 that were not written. The **`_FillValue`** should be outside the range
 specified by **`valid_range`** (if used) for a variable. The netCDF library
 defines a default fill value for each data type
-(link:$$http://www.unidata.ucar.edu/netcdf/docs/netcdf.html#NetCDF-Classic-Format$$[NUG
-appendix C]).
+(See the "Note on fill values" in link:$$http://www.unidata.ucar.edu/software/netcdf/docs/file_format_specifications.html#classic_format_spec$$[NUG Appendix B, File Format Specifications]).
 
 The missing values of a variable with **`scale_factor`** and/or
 **`add_offset`** attributes (see <<packed-data>>) are
@@ -129,7 +128,7 @@ even when there is no inheritance relationship among the conventions. In this ca
 the value of the Conventions attribute may be a single text string containing a list 
 of the convention names separated by blank space (recommended) or commas (if a convention 
 name contains blanks). This is the Unidata recommended syntax from NetCDF Users Guide, 
-Appendix B. If the string contains any commas, it is assumed to be a comma-separated list.
+Appendix A. If the string contains any commas, it is assumed to be a comma-separated list.
 
 When CF is listed with other conventions, this asserts the same full compliance with CF 
 requirements and interpretations as if CF was the sole convention. It is the responsibility 

--- a/history.adoc
+++ b/history.adoc
@@ -165,6 +165,9 @@ Replaced first para in Section 9.6. "Missing Data". Added verbiage to Section 2.
 . Ticket #140, Added 3 paragraphs and an example to Chapter 7, Section 7.1.
 
 .18 July 2017
-. final formatting tweaks
+. a few formatting tweaks
 . Where appropriate, changed document version from 1.6 to 1.7, and 1.7 (DRAFT) to 1.7.
-. This Version 1.7 is the final draft and will be released shortly.
+
+.1 August 2017
+. Updated the links and references to NUG (The NetCDF User Guide), to refer to the current version.
+. Trivial updates to links for COARDS and UDUNITS in the bibliography.


### PR DESCRIPTION
. Updated the links and references to NUG (The NetCDF User Guide), to refer to the current version.
. Trivial updates to links for COARDS and UDUNITS in the bibliography.

I didn't create a Trac ticket for this because it is highly non-controversial.