### PR TITLE
Add definition of 'name_strlen' dimension where missing in Appendix H CDL examples

### DIFF
--- a/apph.adoc
+++ b/apph.adoc
@@ -76,6 +76,8 @@ If the time series instances have the same number of elements and the time value
    dimensions:
      station = 10 ;  // measurement locations
      time = UNLIMITED ;
+     name_strlen = 23 ;
+
    variables:
      float humidity(station,time) ;
        humidity:standard_name = "specific humidity" ;
@@ -122,6 +124,7 @@ Much of the simplicity of the orthogonal multidimensional representation can be 
    dimensions:
       station = UNLIMITED ;
       obs = 13 ;
+      name_strlen = 23 ;
 
    variables:
       float lon(station) ; 
@@ -296,6 +299,7 @@ When the time series have different lengths and the data values for entire time 
    dimensions:
       station = 23 ;
       obs = 1234 ;
+      name_strlen = 23 ;
 
    variables:
       float lon(station) ; 
@@ -370,6 +374,7 @@ When time series with different lengths are written incrementally, the indexed r
    dimensions:
       station = 23 ;
       obs = UNLIMITED ;
+      name_strlen = 23 ;
 
    variables:
       float lon(station) ; 
@@ -700,6 +705,7 @@ When storing multiple trajectories in the same file, and the number of elements 
    dimensions:
       obs = 1000 ;
       trajectory = 77 ;
+      name_strlen = 23 ;
 
    variables:
       char trajectory(trajectory, name_strlen) ;
@@ -760,6 +766,7 @@ When a single trajectory is stored in the data variable, there is no need for th
 ----
    dimensions:
       time = 42;
+      name_strlen = 23 ;
 
    variables:
       char trajectory(name_strlen) ;
@@ -817,6 +824,7 @@ When the number of elements for each trajectory varies, and one can control the 
    dimensions:
       obs = 3443;
       trajectory = 77 ;
+      name_strlen = 23 ;
    
    variables:
       char trajectory(trajectory, name_strlen) ;
@@ -877,6 +885,7 @@ When the number of elements at each trajectory vary, and the elements cannot be 
    dimensions:
       obs = UNLIMITED ;
       trajectory = 77 ;
+      name_strlen = 23 ;
    
    variables:
       char trajectory(trajectory, name_strlen) ;
@@ -950,6 +959,7 @@ When storing time series of profiles at multiple stations in the same data varia
       station = 22 ;
       profile = 3002 ;
       z = 42 ;
+      name_strlen = 23 ;
    
    variables:
       float lon(station) ; 
@@ -1056,6 +1066,7 @@ If there is only one station in the data variable, there is no need for the stat
    dimensions:
       profile = 30 ;
       z = 42 ;
+      name_strlen = 23 ;
    
    variables:
       float lon ; 
@@ -1123,6 +1134,7 @@ When the number of profiles and levels for each station varies, one can use a ra
       obs = UNLIMITED ;
       profiles = 1420 ;
       stations = 42;
+      name_strlen = 23 ;
    
    variables:
       float lon(station) ; 


### PR DESCRIPTION
This addresses CF Trac ticket #[161](http://cf-trac.llnl.gov/trac/ticket/161), "h.2 name_strlen". That ticket points out one example of a missing `name_strlen` dimension definition. This PR fixes that instance and several others.

 - [x] Added link from trac ticket to this PR?

 > Applied via ​https://github.com/cf-convention/cf-conventions/pull/XXX

 - [ ] Updated "Revision History"? (Use the date you applied the changes.)
