### PR TITLE
[Issue #130] GitHub contribution

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -43,6 +43,10 @@ community it should be vetted in an issue. If the proposal is non-controversial
 (such as a typo correction) or has been agreed to in concept in an issue, then
 detailed review of the text may take place in a pull request.
 
+4. **Use [labels](https://github.com/cf-convention/cf-conventions/labels) on issues 
+and pull requests.** Please attempt to present contributions as enhancements, 
+defects, or typos and label them accordingly. 
+
 ## Issues and Pull Requests
 
 The following cases describe potential patterns of use for issues and pull requests.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,7 +21,7 @@ As of the creation of this version of these guidelines, contributions can also b
 made through the [cf-trac](https://cf-trac.llnl.gov/trac/) infrastructure.
 [Procedures for using trac](http://cfconventions.org/rules.html) are not covered
 here and it is expected that the trac system will be deprecated once the
-community is comfortable using github for the purpose.
+community is comfortable using github for this purpose.
 
 ## General Guidelines
 
@@ -45,12 +45,12 @@ detailed review of the text may take place in a pull request.
 
 ## Issues and Pull Requests
 
-The following cases describe potential patterns of use for Issues.
+The following cases describe potential patterns of use for issues and pull requests.
 
 1. **Typo Fix** If the change is a non-controversial fix such as a typo,
 no issue is required. A pull request with the fix can be submitted directly.
-Contributors not familiar with github are encouraged to submit issues for typos
-and similar issues for others to fix.
+Contributors not familiar with github can submit issues for typos and similar
+issues for others to fix.
 
 2. **Single Section Change** In the case of a change concerning one to a few
 paragraphs, an issue should be opened that describes the problem and proposed

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to the NetCDF-CF conventions
+
+Dear CF community member,
+
+Thank you for taking the time to consider making a contribution to the
+[cf-conventions](http://cfconventions.org/).
+The NetCDF Climate and Forecasting conventions are a product by and for a broad
+community and your contribution is the key to their usefulness.
+
+This set of guidelines provides a brief overview of the practices and procedures
+that should be used in fixing, updating, or adding to the conventions. It builds
+on the [rules for CF Convention changes.](http://cfconventions.org/rules.html)
+
+As a prerequisite to this guide, please review the community's code of
+[conduct.](https://github.com/cf-convention/cf-conventions/blob/master/CODE_OF_CONDUCT.md)
+The CF community takes great pride in respectful and collegial
+discourse. Any disrespectful or otherwise derogatory communication will not be
+tolerated.
+
+As of the creation of this version of these guidelines, contributions can also be
+made through the [cf-trac](https://cf-trac.llnl.gov/trac/) infrastructure.
+[Procedures for using trac](http://cfconventions.org/rules.html) are not covered
+here and it is expected that the trac system will be deprecated once the
+community is comfortable using github for the purpose.
+
+## General Guidelines
+
+1. **A given proposal should be discussed as one issue.** It shouldn't fork or
+be superseded by another one, unless that reflects what has happened to the
+proposal. This is so that it's easy to trace the discussion which led to a
+given agreed proposal.
+
+2. **A proposal should convey the reasoning and effect on all relevant
+sections of the specification.** An overview of all actual changes and the
+impact the changes have on the specification should be clear. Depending on the
+length and nature of the proposal, this may require different approaches as
+described below.
+
+3. **In general, issues should be used for discussion of proposed changes and
+pull requests should be used for review of agreed upon changes.** In other words,
+if the content or concept of what is being proposed needs to be vetted by the
+community it should be vetted in an issue. If the proposal is non-controversial
+(such as a typo correction) or has been agreed to in concept in an issue, then
+detailed review of the text may take place in a pull request.
+
+## Issues and Pull Requests
+
+The following cases describe potential patterns of use for Issues.
+
+1. **Typo Fix** If the change is a non-controversial fix such as a typo,
+no issue is required. A pull request with the fix can be submitted directly.
+Contributors not familiar with github are encouraged to submit issues for typos
+and similar issues for others to fix.
+
+2. **Single Section Change** In the case of a change concerning one to a few
+paragraphs, an issue should be opened that describes the problem and proposed
+fix. The problem text should be pasted in the body of the issue and proposed fix
+included. A link to the line where the problem exists could also be included.
+If the modification is non-controversial, a pull request could be opened
+simultaneously if the reporter is familiar with git and github. Discussion of
+the proposal should take place in one issue. Once accepted, a pull request could
+be submitted implementing the suggested change. Final review should take place
+in the pull request and the issue closed when the pull request is merged.
+
+3. **Changes Spanning Multiple Sections** If reasonable, changes concerning
+multiple sections should follow the patter described Single Section Change.
+If explicitly listing proposed changes is not practical, general guideline
+2 should be followed to document the proposal. Depending on the nature of the
+proposal, interested community members can decide what the most effective tool
+is for development and review of specification changes. Some proposals have
+been developed in google docs and contributed as a pull request after general
+consensus has been reached, but the specific tools used for development of
+significant changes is up to those contributing and reviewing it.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,13 @@
-See http://cf-trac.llnl.gov/trac/ticket/XXX
+_If trac was used for review of contribution:_  
+See http://cf-trac.llnl.gov/trac/ticket/XXX  
 
  - [ ] Added link from trac ticket to this PR?
 
  > Applied via ​https://github.com/cf-convention/cf-conventions/pull/XXX
+
+ - [ ] Updated "Revision History"? (Use the date you applied the changes.)
+
+_If github issues were used for review:_  
+See issue #XXX
 
  - [ ] Updated "Revision History"? (Use the date you applied the changes.)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,25 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating 
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for
+everyone, regardless of level of experience, gender, gender identity and expression,
+sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or
+imagery, derogatory comments or personal attacks, trolling, public or private harassment,
+insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments,
+commits, code, wiki edits, issues, and other contributions that are not aligned to this
+Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed
+from the project team.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by
+opening an issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the Contributor Covenant
+(http:contributor-covenant.org), version 1.0.0, available at
+http://contributor-covenant.org/version/1/0/0/


### PR DESCRIPTION
It seems that #130 has come to near consensus regarding its main purpose. This pull request is draft text for the group to evolve to make sure we get the message right. 

Note that this text was already evolved slightly by @ChrisBarker-NOAA and I in https://github.com/dblodgett-usgs/cf-conventions/pull/10 and I think it is now ready for the broader community to tinker with. 

**Note 1:** Please consider commenting inline with the text in the "files changed" tab. I've used a rather short line-length to try to facilitate detailed comment tracking on the text. How we review text with these tools is a work in progress that we'll only figure out by trying it out!

**Note 2:** I am about to submit a companion pull request over here: https://github.com/cf-convention/cf-convention.github.io with suggested changes to http://cfconventions.org/rules.html -- stay tuned for that.