### PR TITLE
Add support for variables of type string

### DIFF
--- a/ch02.adoc
+++ b/ch02.adoc
@@ -22,16 +22,17 @@ are treated by the netCDF interface as signed. It is possible to treat the
 unsigned range using the **`valid_min`**, **`valid_max`**, or **`valid_range`**
 attributes.
 
-Strings in variables may represented one of two ways - as atomic strings or as
-character arrays.  An n-dimensional array of strings may be implemented as a
+Strings in variables may be represented one of two ways - as atomic strings or
+as character arrays.  An n-dimensional array of strings may be implemented as a
 variable of type **`string`** with n dimensions, or as a variable of type
 **`char`** with n+1 dimensions where the last (most rapidly varying) dimension
-is large enough to contain the longest string in the variable.  If the
-character array option is chosen, the strings in a given array are defined to
-be equal in length. For example, an array of strings containing the names of
-the months would be dimensioned (12,9) in order to accommodate "September", the
-month with the longest name. If the atomic string option is chosen, each
-element of the array can be assigned a string with a different length.
+is large enough to contain the longest string in the variable. For example, a
+character array variable of strings containing the names of the months would be
+dimensioned (12,9) in order to accommodate "September", the month with the
+longest name. The other strings, such as "May", should be padded with trailing
+NULL or space characters so that every array element is filled. If the atomic
+string option is chosen, each element of the variable can be assigned a string
+with a different length.
 
 
 

--- a/ch02.adoc
+++ b/ch02.adoc
@@ -13,9 +13,25 @@ NetCDF files should have the file name extension "**`.nc`**".
 
 === Data Types
 
-The netCDF data types **`char`**, **`byte`**, **`short`**, **`int`**, **`float`** or **`real`**, and **`double`** are all acceptable. The **`char`** type is not intended for numeric data. One byte numeric data should be stored using the **`byte`** data type. All integer types are treated by the netCDF interface as signed. It is possible to treat the **`byte`** type as unsigned by using the NUG convention of indicating the unsigned range using the **`valid_min`**, **`valid_max`**, or **`valid_range`** attributes.
+The netCDF data types **`string`**, **`char`**, **`byte`**, **`short`**,
+**`int`**, **`float`** or **`real`**, and **`double`** are all acceptable.  The
+**`char`** and **`string`** types are not intended for numeric data. One byte
+numeric data should be stored using the **`byte`** data type. All integer types
+are treated by the netCDF interface as signed. It is possible to treat the
+**`byte`** type as unsigned by using the NUG convention of indicating the
+unsigned range using the **`valid_min`**, **`valid_max`**, or **`valid_range`**
+attributes.
 
-NetCDF does not support a character string type, so these must be represented as character arrays. In this document, a one dimensional array of character data is simply referred to as a "string". An n-dimensional array of strings must be implemented as a character array of dimension (n,max_string_length), with the last (most rapidly varying) dimension declared large enough to contain the longest string in the array. All the strings in a given array are therefore defined to be equal in length. For example, an array of strings containing the names of the months would be dimensioned (12,9) in order to accommodate "September", the month with the longest name.
+Strings in variables may represented one of two ways - as atomic strings or as
+character arrays.  An n-dimensional array of strings may be implemented as a
+variable of type **`string`** with n dimensions, or as a variable of type
+**`char`** with n+1 dimensions where the last (most rapidly varying) dimension
+is large enough to contain the longest string in the variable.  If the
+character array option is chosen, the strings in a given array are defined to
+be equal in length. For example, an array of strings containing the names of
+the months would be dimensioned (12,9) in order to accommodate "September", the
+month with the longest name. If the atomic string option is chosen, each
+element of the array can be assigned a string with a different length.
 
 
 

--- a/history.adoc
+++ b/history.adoc
@@ -174,3 +174,6 @@ Replaced first para in Section 9.6. "Missing Data". Added verbiage to Section 2.
 
 .10 August 2017
 . Updated use of WKT-CRS syntax.
+
+.19 July 2018
+. Added support for variables of type string.


### PR DESCRIPTION
Change the Data Types section to include the string type and change the description of variables containing text data to include atomic string elements in addition to character arrays.

See http://cf-trac.llnl.gov/trac/ticket/XXX (Trac unavailable right now.)

 - [ ] Added link from trac ticket to this PR? (Trac unavailable right now.)

 > Applied via ​https://github.com/cf-convention/cf-conventions/pull/138

 - [x ] Updated "Revision History"? (Use the date you applied the changes.)
