### PR TITLE
Fix bad reference to an example in section 6.1 "Labels"

### DIFF
--- a/ch06.adoc
+++ b/ch06.adoc
@@ -17,8 +17,9 @@ element of an axis. This is particularly useful for discrete axes
 observational data from a number of observing stations, it may be
 convenient to provide the names of the stations as labels for the
 elements of the station dimension (<<time-series-data>>).
-      <<example-h.1>> illustrates another application for labels.
-      
+There are several other uses for labels in CF. For instance,
+<<northward-heat-transport-in-atlantic-ocean-ex>> shows the use of labels
+to indicate geographic regions.
 
 Character strings labelling the elements of an axis are regarded as
 string-valued auxiliary coordinate variables. The **`coordinates`**
@@ -41,7 +42,7 @@ to the data variable. This is a convenience feature.
 When data is representative of geographic regions which can be identified by names but which have complex boundaries that cannot practically be specified using longitude and latitude boundary coordinates, a labeled axis should be used to identify the regions. We recommend that the names be chosen from the list of link:$$http://cfconventions.org/Data/cf-standard-names/docs/standardized-region-names.html$$[standardized region names] whenever possible. To indicate that the label values are standardized the variable that contains the labels must be given the **`standard_name`** attribute with the value `region`.
 
 [[northward-heat-transport-in-atlantic-ocean-ex]]
-[caption="Example 6.2. "]
+[caption="Example 6.1. "]
 .Northward heat transport in Atlantic Ocean
 ====
 
@@ -83,7 +84,7 @@ data:
 In some situations a dimension may have alternative sets of coordinates values. Since there can only be one coordinate variable for the dimension (the variable with the same name as the dimension), any alternative sets of values have to be stored in auxiliary coordinate variables. For such alternative coordinate variables, there are no mandatory attributes, but they may have any of the attributes allowed for coordinate variables.
 
 [[model-level-numbers-ex]]
-[caption="Example 6.3. "]
+[caption="Example 6.2. "]
 .Model level numbers
 ====
 

--- a/toc-extra.adoc
+++ b/toc-extra.adoc
@@ -35,8 +35,8 @@ F.1. <<table-grid-mapping-attributes>>
 5.11. <<latitude-and-longitude-on-the-wgs-1984-datum-in-crs-wkt-format>>
 5.12. <<british-national-grid-newlyn-datum-in-crs-wkt-format>>
 5.13. <<multiple-forecasts-from-single-analysis>>
-6.2. <<northward-heat-transport-in-atlantic-ocean-ex>>
-6.3. <<model-level-numbers-ex>>
+6.1. <<northward-heat-transport-in-atlantic-ocean-ex>>
+6.2. <<model-level-numbers-ex>>
 7.1. <<cells-on-a-latitude-axis-ex>>
 7.2. <<cells-in-a-non-rectangular-grid-ex>>
 7.3. <<cell-areas-for-a-spherical-geodesic-grid>>


### PR DESCRIPTION
Fix for bad reference to an example in section 6.1 "Labels". Also update numbering of examples in chapter 6.

See http://cf-trac.llnl.gov/trac/ticket/XXX

 - [ ] Added link from trac ticket to this PR?

 > Applied via ​https://github.com/cf-convention/cf-conventions/pull/XXX

 - [ ] Updated "Revision History"? (Use the date you applied the changes.)
