### PR TITLE
Typos (plural dimensions) in section H

### DIFF
--- a/apph.adoc
+++ b/apph.adoc
@@ -628,7 +628,7 @@ When the number of vertical levels for each profile varies, and one cannot write
 ----
    dimensions:
       obs = UNLIMITED ;
-      profiles = 142 ;
+      profile = 142 ;
 
    variables:
       int profile(profile) ;
@@ -1121,8 +1121,8 @@ When the number of profiles and levels for each station varies, one can use a ra
 ----
    dimensions:
       obs = UNLIMITED ;
-      profiles = 1420 ;
-      stations = 42;
+      profile = 1420 ;
+      station = 42;
    
    variables:
       float lon(station) ; 
@@ -1341,7 +1341,7 @@ When the number of profiles and levels for each trajectory varies, one can use a
 ----
    dimensions:
       obs = UNLIMITED ;
-      profiles = 142 ;
+      profile = 142 ;
    
    variables:
       int trajectory(trajectory) ;


### PR DESCRIPTION
There are few examples in section H with inconsistent dimensions alternating between plural and singular:

  - profiles x profile
  - station x stations

See http://cf-trac.llnl.gov/trac/ticket/XXX

 - [ ] Added link from trac ticket to this PR?

 > Applied via https://github.com/cf-convention/cf-conventions/pull/XXX

 - [ ] Updated "Revision History"? (Use the date you applied the changes.)
