### PR TITLE
update to 1.8 and fix authors

### DIFF
--- a/cf-conventions.adoc
+++ b/cf-conventions.adoc
@@ -1,6 +1,6 @@
 ﻿= NetCDF Climate and Forecast (CF) Metadata Conventions
-Brian Eaton; Jonathan Gregory; Bob Drach; Karl Taylor; Steve Hankin; Jon Blower; John Caron; Rich Signell; Phil Bentley; Greg Rappa; Heinke Höck; Alison Pamment; Martin Juckes; Martin Raspaud
-Version 1.7
+Brian Eaton; Jonathan Gregory; Bob Drach; Karl Taylor; Steve Hankin; Jon Blower; John Caron; Rich Signell; Phil Bentley; Greg Rappa; Heinke Höck; Alison Pamment; Martin Juckes; Martin Raspaud; Randy Horne; Timothy Whiteaker; David Blodgett
+Version 1.8
 :sectanchors:
 :toc: macro
 :toclevels: 3


### PR DESCRIPTION
The header information here: is out of date. This fixes that.
http://cfconventions.org/cf-conventions/cf-conventions.html