### PR TITLE
update readme and add 1.8 (draft) to title

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ### Status
 
-This repository contains the official source of the CF metadata conventions. The source files are built into HTML (see below), thw output of which can be seen at: http://cfconventions.org/cf-conventions/cf-conventions.html.
+This repository contains the official source of the CF metadata conventions. 
+The source files are built into HTML automatically when changes are merged into this repository. 
+The latest build of the specfication is held in the `gh-pages` branch and can be seen at: http://cfconventions.org/cf-conventions/cf-conventions.html.
 
 For the official web site please visit: http://cfconventions.org/,
 and the corresponding GitHub organisation: https://github.com/cf-convention.

--- a/cf-conventions.adoc
+++ b/cf-conventions.adoc
@@ -1,6 +1,6 @@
 = NetCDF Climate and Forecast (CF) Metadata Conventions
 Brian{nbsp}Eaton; Jonathan{nbsp}Gregory; Bob{nbsp}Drach; Karl{nbsp}Taylor; Steve{nbsp}Hankin; Jon{nbsp}Blower; John{nbsp}Caron; Rich{nbsp}Signell; Phil{nbsp}Bentley; Greg{nbsp}Rappa; Heinke{nbsp}Höck; Alison{nbsp}Pamment; Martin{nbsp}Juckes; Martin{nbsp}Raspaud; Randy{nbsp}Horne; Timothy{nbsp}Whiteaker; David{nbsp}Blodgett; Charlie{nbsp}Zender; Daniel{nbsp}Lee
-Version 1.7
+Version 1.8 (draft)
 :doctype: book
 :pdf-folio-placement: physical
 :sectanchors:


### PR DESCRIPTION
Just a little housekeeping. Clarifying how the automated build works in the readme and updating the version of the spec to 1.8 (draft) in the title.