### PR TITLE
Missing dimension trajectory in H.22

### DIFF
--- a/apph.adoc
+++ b/apph.adoc
@@ -1353,6 +1353,7 @@ When the number of profiles and levels for each trajectory varies, one can use a
 ----
    dimensions:
       obs = UNLIMITED ;
+      trajectory = 22 ;
       profile = 142 ;
    
    variables:


### PR DESCRIPTION
Variable trajectory uses dimension trajectory, which was missing.

See issue #136 for discussion of these changes.