### PR TITLE
Clarification to use of groups

### DIFF
--- a/ch01.adoc
+++ b/ch01.adoc
@@ -60,6 +60,8 @@ nearest item:: The item (variable or group) that can be reached via the shortest
 
 out-of-group reference:: A reference to a variable or dimension that is not contained in the referring group.
 
+path:: Paths must follow the UNIX style path convention and may begin with either a '/', '..', or a word.
+
 recommendation:: Recommendations in this convention are meant to provide advice that may be helpful for reducing common mistakes. In some cases we have recommended rather than required particular attributes in order to maintain backwards compatibility with COARDS. An application must not depend on a dataset's adherence to recommendations.
 
 referring group:: The group in which a reference to a variable or dimension occurs.
@@ -81,7 +83,7 @@ vertical dimension:: A dimension of a netCDF variable that has an associated ver
 
 === Overview
 
-No variable or dimension names are standardized by this convention. Instead we follow the lead of the NUG and standardize only the names of attributes and some of the values taken by those attributes. The overview provided in this section will be followed with more complete descriptions in following sections. <<attribute-appendix>> contains a summary of all the attributes used in this convention.
+No variable or dimension names are standardized by this convention. Instead we follow the lead of the NUG and standardize only the names of attributes and some of the values taken by those attributes. Variable or dimension names can either be a single variable name or a path to a variable. The overview provided in this section will be followed with more complete descriptions in following sections. <<attribute-appendix>> contains a summary of all the attributes used in this convention.
 
 We recommend that the NUG defined attribute **`Conventions`** be given the string value     "**`CF-1.8`**" to identify datasets that conform to these conventions.
 

--- a/ch02.adoc
+++ b/ch02.adoc
@@ -62,7 +62,7 @@ these two forms.
 
 === Naming Conventions
 
-Variable, dimension and attribute names should begin with a letter and be composed of letters, digits, and underscores. Note that this is in conformance with the COARDS conventions, but is more restrictive than the netCDF interface which allows use of the hyphen character. The netCDF interface also allows leading underscores in names, but the NUG states that this is reserved for system use.
+Variable, dimension, attribute and group names should begin with a letter and be composed of letters, digits, and underscores. Note that this is in conformance with the COARDS conventions, but is more restrictive than the netCDF interface which allows use of the hyphen character. The netCDF interface also allows leading underscores in names, but the NUG states that this is reserved for system use.
 
 Case is significant in netCDF names, but it is recommended that names should not be distinguished purely by case, i.e., if case is disregarded, no two names should be the same. It is also recommended that names should be obviously meaningful, if possible, as this renders the file more effectively self-describing.
 


### PR DESCRIPTION
Variable and dimension names can be either a single variable name or a path to a variable
Add definition of path
Recommend that group names follow the same convention as variable and dimension names (ie. that they are composed of letters, digits and underscores)

See issue #203 for discussion of these changes.