### PR TITLE
Update usage of false_easting and false_northing in projections

### DIFF
--- a/appf.adoc
+++ b/appf.adoc
@@ -433,9 +433,8 @@ to a reference direction.
 |  Applied to all abscissa values in the rectangular
     coordinates for a map projection in order to eliminate negative numbers. Expressed in
     the unit of the coordinate variable identified by the
-    standard name **`projection_x_coordinate`**. If 
-    **`false_easting`** is not provided it is assumed 
-    to be 0.
+    standard name **`projection_x_coordinate`**. 
+    If **`false_easting`** is not provided it is assumed to be 0.
     The formula to convert from the coordinate value as written in the **`projection_x_coordinate`**
     (xf) to a value (x0) used in a transformation without **`false_easting`**, i.e. **`false_easting`**= 0, is:
     x0 = xf -**`false_easting`**
@@ -446,9 +445,8 @@ to a reference direction.
 |  Applied to all ordinate values in the rectangular
     coordinates for a map projection in order to eliminate negative numbers. Expressed in
     the unit of the coordinate variable identified by the
-    standard name **`projection_y_coordinate`**. If 
-    **`false_northing`** is not provided it is assumed 
-    to be 0.
+    standard name **`projection_y_coordinate`**. 
+    If **`false_northing`** is not provided it is assumed to be 0.
     The formula to convert from the coordinate value as written in the **`projection_y_coordinate`**
     (yf) to a value (y0) used in a transformation without **`false_northing`**, i.e. **`false_northing`**= 0, is:
     y0 = yf -**`false_northing`**

--- a/appf.adoc
+++ b/appf.adoc
@@ -31,8 +31,8 @@ __Map parameters:__::
 * **`standard_parallel`** - There may be 1 or 2 values.
 * **`longitude_of_central_meridian`**
 * **`latitude_of_projection_origin`**
-* **`false_easting`**
-* **`false_northing`**
+* **`false_easting`** - This parameter is optional (default is 0)
+* **`false_northing`** - This parameter is optional (default is 0)
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
@@ -52,8 +52,8 @@ grid_mapping_name = azimuthal_equidistant
 __Map parameters:__::
 * **`longitude_of_projection_origin`**
 * **`latitude_of_projection_origin`**
-* **`false_easting`**
-* **`false_northing`**
+* **`false_easting`** - This parameter is optional (default is 0)
+* **`false_northing`** - This parameter is optional (default is 0)
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
@@ -74,8 +74,8 @@ __Map parameters:__::
 * **`latitude_of_projection_origin`**
 * **`longitude_of_projection_origin`**
 * **`perspective_point_height`**
-* **`false_easting`**
-* **`false_northing`**
+* **`false_easting`** - This parameter is optional (default is 0)
+* **`false_northing`** - This parameter is optional (default is 0)
 * **`sweep_angle_axis`**
 * **`fixed_angle_axis`**
 
@@ -104,8 +104,8 @@ grid_mapping_name = lambert_azimuthal_equal_area
 __Map parameters:__::
 * **`longitude_of_projection_origin`**
 * **`latitude_of_projection_origin`**
-* **`false_easting`**
-* **`false_northing`**
+* **`false_easting`** - This parameter is optional (default is 0)
+* **`false_northing`** - This parameter is optional (default is 0)
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
@@ -127,8 +127,8 @@ __Map parameters:__::
 * **`standard_parallel`** - There may be 1 or 2 values.
 * **`longitude_of_central_meridian`**
 * **`latitude_of_projection_origin`**
-* **`false_easting`**
-* **`false_northing`**
+* **`false_easting`** - This parameter is optional (default is 0)
+* **`false_northing`** - This parameter is optional (default is 0)
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
@@ -150,8 +150,8 @@ grid_mapping_name = lambert_cylindrical_equal_area
 __Map parameters:__::
 * **`longitude_of_central_meridian`**
 * Either **`standard_parallel`** or **`scale_factor_at_projection_origin`** (deprecated)
-* **`false_easting`**
-* **`false_northing`**
+* **`false_easting`** - This parameter is optional (default is 0)
+* **`false_northing`** - This parameter is optional (default is 0)
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
@@ -188,8 +188,8 @@ grid_mapping_name = mercator
 __Map parameters:__::
 * **`longitude_of_projection_origin`**
 * Either **`standard_parallel`** (EPSG 9805) or **`scale_factor_at_projection_origin`** (EPSG 9804)
-* **`false_easting`**
-* **`false_northing`**
+* **`false_easting`** - This parameter is optional (default is 0)
+* **`false_northing`** - This parameter is optional (default is 0)
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
@@ -219,8 +219,8 @@ __Map parameters:__::
 * **`latitude_of_projection_origin`**
 * **`longitude_of_projection_origin`**
 * **`scale_factor_at_projection_origin`**
-* **`false_easting`**
-* **`false_northing`**
+* **`false_easting`** - This parameter is optional (default is 0)
+* **`false_northing`** - This parameter is optional (default is 0)
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
@@ -242,8 +242,8 @@ grid_mapping_name = orthographic
 __Map parameters:__::
 * **`longitude_of_projection_origin`**
 * **`latitude_of_projection_origin`**
-* **`false_easting`**
-* **`false_northing`**
+* **`false_easting`** - This parameter is optional (default is 0)
+* **`false_northing`** - This parameter is optional (default is 0)
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
@@ -271,8 +271,8 @@ __Map parameters:__::
 * **`straight_vertical_longitude_from_pole`**
 * **`latitude_of_projection_origin`** - Either +90. or -90.
 * Either **`standard_parallel`** (EPSG 9829) or **`scale_factor_at_projection_origin`** (EPSG 9810)
-* **`false_easting`**
-* **`false_northing`**
+* **`false_easting`** - This parameter is optional (default is 0)
+* **`false_northing`** - This parameter is optional (default is 0)
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
@@ -312,8 +312,8 @@ grid_mapping_name = sinusoidal
 
 __Map parameters:__::
 * **`longitude_of_projection_origin`**
-* **`false_easting`**
-* **`false_northing`**
+* **`false_easting`** - This parameter is optional (default is 0)
+* **`false_northing`** - This parameter is optional (default is 0)
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
@@ -336,8 +336,8 @@ __Map parameters:__::
 * **`longitude_of_projection_origin`**
 * **`latitude_of_projection_origin`**
 * **`scale_factor_at_projection_origin`**
-* **`false_easting`**
-* **`false_northing`**
+* **`false_easting`** - This parameter is optional (default is 0)
+* **`false_northing`** - This parameter is optional (default is 0)
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
@@ -360,8 +360,8 @@ __Map parameters:__::
 * **`scale_factor_at_central_meridian`**
 * **`longitude_of_central_meridian`**
 * **`latitude_of_projection_origin`**
-* **`false_easting`**
-* **`false_northing`**
+* **`false_easting`** - This parameter is optional (default is 0)
+* **`false_northing`** - This parameter is optional (default is 0)
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
@@ -384,8 +384,8 @@ __Map parameters:__::
 * **`latitude_of_projection_origin`**
 * **`longitude_of_projection_origin`**
 * **`perspective_point_height`**
-* **`false_easting`**
-* **`false_northing`**
+* **`false_easting`** - This parameter is optional (default is 0)
+* **`false_northing`** - This parameter is optional (default is 0)
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular
 coordinates are identified by the **`standard_name`** attribute value
@@ -433,7 +433,9 @@ to a reference direction.
 |  Applied to all abscissa values in the rectangular
     coordinates for a map projection in order to eliminate negative numbers. Expressed in
     the unit of the coordinate variable identified by the
-    standard name **`projection_x_coordinate`**.
+    standard name **`projection_x_coordinate`**. If 
+    **`false_easting`** is not provided it is assumed 
+    to be 0.
     The formula to convert from the coordinate value as written in the **`projection_x_coordinate`**
     (xf) to a value (x0) used in a transformation without **`false_easting`**, i.e. **`false_easting`**= 0, is:
     x0 = xf -**`false_easting`**
@@ -444,7 +446,9 @@ to a reference direction.
 |  Applied to all ordinate values in the rectangular
     coordinates for a map projection in order to eliminate negative numbers. Expressed in
     the unit of the coordinate variable identified by the
-    standard name **`projection_y_coordinate`**.
+    standard name **`projection_y_coordinate`**. If 
+    **`false_northing`** is not provided it is assumed 
+    to be 0.
     The formula to convert from the coordinate value as written in the **`projection_y_coordinate`**
     (yf) to a value (y0) used in a transformation without **`false_northing`**, i.e. **`false_northing`**= 0, is:
     y0 = yf -**`false_northing`**

--- a/appf.adoc
+++ b/appf.adoc
@@ -294,7 +294,7 @@ grid_mapping_name = rotated_latitude_longitude
 __Map parameters:__::
 * **`grid_north_pole_latitude`**
 * **`grid_north_pole_longitude`**
-* **`north_pole_grid_longitude`** - This parameter is option (default is 0).
+* **`north_pole_grid_longitude`** - This parameter is optional (default is 0).
 
 __Map coordinates:__:: The rotated latitude and longitude coordinates are identified by the **`standard_name`** attribute values **`grid_latitude`** and **`grid_longitude`** respectively.
 


### PR DESCRIPTION
The projection parameters `false_easting` and `false_northing` should be considered as optional for all projections. If they do not exist, they should be assumed to be `0`. This was added to the definitions of these parameters.

See issue #212 for discussion of these changes.