### PR TITLE
Amend broken link (RE COARDS Conventions) in bibliography

### DIFF
--- a/bibliography.adoc
+++ b/bibliography.adoc
@@ -3,7 +3,7 @@
 [bibliography]
 === References
 
-- [[[COARDS]]]  link:$$http://www.ferret.noaa.gov/noaa_coop/coop_cdf_profile.html$$[ Conventions for the standardization of NetCDF Files ] .
+- [[[COARDS]]]  link:$$https://ferret.pmel.noaa.gov/Ferret/documentation/coards-netcdf-conventions$$[ Conventions for the standardization of NetCDF Files ] .
 					Sponsored by the "Cooperative
 					Ocean/Atmosphere Research Data
 					Service," a NOAA/university


### PR DESCRIPTION
No corresponding issue, as this is a uncontroversial one-line change to fix a broken link.

See also Issue cf-convention/cf-convention.github.io#74 which registers an equivalent reference to the obsolete URL on the website, & where I have commented regarding the choice of replacement link (in short, with a change of the path as well as for the new NOAA Ferret host, the same content is kept included but high-up on the core sitemap).