### PR TITLE
set version string to 1.9 (draft)

### DIFF
--- a/cf-conventions.adoc
+++ b/cf-conventions.adoc
@@ -1,6 +1,6 @@
 = NetCDF Climate and Forecast (CF) Metadata Conventions
 Brian{nbsp}Eaton; Jonathan{nbsp}Gregory; Bob{nbsp}Drach; Karl{nbsp}Taylor; Steve{nbsp}Hankin; Jon{nbsp}Blower; John{nbsp}Caron; Rich{nbsp}Signell; Phil{nbsp}Bentley; Greg{nbsp}Rappa; Heinke{nbsp}Höck; Alison{nbsp}Pamment; Martin{nbsp}Juckes; Martin{nbsp}Raspaud; Randy{nbsp}Horne; Timothy{nbsp}Whiteaker; David{nbsp}Blodgett; Charlie{nbsp}Zender; Daniel{nbsp}Lee
-Version 1.8
+Version 1.9 (draft)
 :doctype: book
 :pdf-folio-placement: physical
 :sectanchors:


### PR DESCRIPTION
Hello @painter1 @davidhassell 

I think that this PR is editorial only. It simply updates the version string to 1.9 (draft), to ensure that the nightly build of latest is not version stamped as 1.8, now that the 1.8 tag is minted and published.

I hope this is a useful and timely step

thank you
mark
