### PR TITLE
replaced PROJ.4 by PROJ; updated URLs; fixed #253

### DIFF
--- a/appf.adoc
+++ b/appf.adoc
@@ -36,7 +36,9 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at
+__Notes:__:: Notes on using the **`PROJ`** software package for computing the mapping may be found at
+link:$$https://proj.org/operations/projections/aea.html$$[https://proj.org/operations/projections/aea.html]
+and
 link:$$http://geotiff.maptools.org/proj_list/albers_equal_area_conic.html$$[http://geotiff.maptools.org/proj_list/albers_equal_area_conic.html].
 
 
@@ -57,10 +59,10 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at
+__Notes:__:: Notes on using the **`PROJ`** software package for computing the mapping may be found at
 link:$$http://geotiff.maptools.org/proj_list/azimuthal_equidistant.html$$[http://geotiff.maptools.org/proj_list/azimuthal_equidistant.html]
 and
-link:$$http://proj4.org/projections/aeqd.html$$[http://proj4.org/projections/aeqd.html].
+link:$$https://proj.org/operations/projections/aeqd.html$$[https://proj.org/operations/projections/aeqd.html].
 
 === Geostationary projection
 
@@ -87,7 +89,10 @@ __Notes:__:: The algorithm for computing the mapping may be found at link:$$http
 This document assumes the point of observation is directly over the equator, and that the **`sweep_angle_axis`** is y.
 
 +
-Notes on using the PROJ.4 software packages for computing the mapping may be found at  link:$$http://proj4.org/$$[http://proj4.org/] and  link:$$https://trac.osgeo.org/geotiff/$$[https://trac.osgeo.org/geotiff/] .
+Notes on using the **`PROJ`** software packages for computing the mapping may be found at
+link:$$https://proj.org/operations/projections/geos.html$$[https://proj.org/operations/projections/geos.html]
+and
+link:$$https://trac.osgeo.org/geotiff/$$[https://trac.osgeo.org/geotiff/].
 
 +
 The **`perspective_point_height`** is the distance to the surface of the ellipsoid.
@@ -123,8 +128,8 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at
-link:$$http://proj4.org/projections/laea.html$$[http://proj4.org/projections/laea.html]
+__Notes:__:: Notes on using the **`PROJ`** software package for computing the mapping may be found at
+link:$$https://proj.org/operations/projections/laea.html$$[https://proj.org/operations/projections/laea.html]
 and
 link:$$http://geotiff.maptools.org/proj_list/lambert_azimuthal_equal_area.html$$[http://geotiff.maptools.org/proj_list/lambert_azimuthal_equal_area.html]
 
@@ -146,12 +151,12 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at link:$$http://proj4.org/projections/lcc.html$$[http://proj4.org/projections/lcc.html].
+__Notes:__:: Notes on using the **`PROJ`** software package for computing the mapping may be found at link:$$https://proj.org/operations/projections/lcc.html$$[https://proj.org/operations/projections/lcc.html].
 and
 link:$$http://geotiff.maptools.org/proj_list/lambert_conic_conformal_1sp.html$$[http://geotiff.maptools.org/proj_list/lambert_conic_conformal_1sp.html]
 ("Lambert Conic Conformal (1SP)" or EPSG 9801) or
 link:$$http://geotiff.maptools.org/proj_list/lambert_conic_conformal_2sp.html$$[http://geotiff.maptools.org/proj_list/lambert_conic_conformal_2sp.html]
- ("Lambert Conic Conformal (2SP)" or EPSG 9802). For the 1SP variant, latitude_of_projection_origin=standard_parallel and the PROJ.4 scale factor is 1.
+ ("Lambert Conic Conformal (2SP)" or EPSG 9802). For the 1SP variant, latitude_of_projection_origin=standard_parallel and the PROJ scale factor is 1.
 
 === Lambert Cylindrical Equal Area
 
@@ -169,7 +174,9 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Notes on using the PROJ.4 software packages for computing the mapping may be found at
+__Notes:__:: Notes on using the **`PROJ`** software packages for computing the mapping may be found at
+link:$$https://proj.org/operations/projections/cea.html$$[https://proj.org/operations/projections/cea.html]
+and
 link:$$http://geotiff.maptools.org/proj_list/cylindrical_equal_area.html$$[http://geotiff.maptools.org/proj_list/cylindrical_equal_area.html]
 ("Lambert Cylindrical Equal Area" or EPSG 9834 or EPSG 9835). Detailed formulas can be found in <<bibliography.adoc#Snyder>> pages 76-85.
 
@@ -205,8 +212,8 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Notes on using the PROJ.4 software packages for computing the mapping may be found at
-link:$$http://proj4.org/projections/merc.html$$[http://proj4.org/projections/merc.html]
+__Notes:__:: Notes on using the **`PROJ`** software packages for computing the mapping may be found at
+link:$$https://proj.org/operations/projections/merc.html$$[https://proj.org/operations/projections/merc.html]
 and
 link:$$http://geotiff.maptools.org/proj_list/mercator_1sp.html$$[http://geotiff.maptools.org/proj_list/mercator_1sp.html]
 ("Mercator (1SP)" or EPSG 9804)
@@ -236,8 +243,8 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at
-link:$$http://proj4.org/projections/omerc.html$$[http://proj4.org/projections/omerc.html]
+__Notes:__:: Notes on using the **`PROJ`** software package for computing the mapping may be found at
+link:$$https://proj.org/operations/projections/omerc.html$$[https://proj.org/operations/projections/omerc.html]
 and
 link:$$http://geotiff.maptools.org/proj_list/oblique_mercator.html$$[http://geotiff.maptools.org/proj_list/oblique_mercator.html].
 The Rotated Mercator projection is an Oblique Mercator projection with azimuth = +90.
@@ -259,8 +266,8 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Notes on using the PROJ.4 software packages for computing the mapping may be found at
-link:$$http://proj4.org/projections/ortho.html$$[http://proj4.org/projections/ortho.html]
+__Notes:__:: Notes on using the **`PROJ`** software packages for computing the mapping may be found at
+link:$$https://proj.org/operations/projections/ortho.html$$[https://proj.org/operations/projections/ortho.html]
 and
 link:$$http://geotiff.maptools.org/proj_list/orthographic.html$$[http://geotiff.maptools.org/proj_list/orthographic.html]
 ("Orthographic" or EPSG 9840).
@@ -288,12 +295,15 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at link:$$http://geotiff.maptools.org/proj_list/polar_stereographic.html$$[http://geotiff.maptools.org/proj_list/polar_stereographic.html]
+__Notes:__:: Notes on using the **`PROJ`** software package for computing the mapping may be found at
+link:$$https://proj.org/operations/projections/ups.html$$[https://proj.org/operations/projections/ups.html]
+and
+link:$$http://geotiff.maptools.org/proj_list/polar_stereographic.html$$[http://geotiff.maptools.org/proj_list/polar_stereographic.html].
 
 The standard_parallel variant corresponds to EPSG Polar Stereographic (Variant B) (EPSG dataset coordinate operation method code 9829),
 while the scale_factor_at_projection_origin variant corresponds to EPSG Polar Stereographic (Variant A)
 (EPSG dataset coordinate operation method code 9810).
-As PROJ.4 requires the standard parallel, [Snyder] formula 21-7 can be used to compute it from the scale factor if needed.
+As PROJ requires the standard parallel, [Snyder] formula 21-7 can be used to compute it from the scale factor if needed.
 
 === Rotated pole
 
@@ -329,8 +339,8 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Notes on using the **`PROJ.4`** software package for computing the mapping may be found at
-link:$$http://proj4.org/projections/sinu.html$$[http://proj4.org/projections/sinu.html]
+__Notes:__:: Notes on using the **`PROJ`** software package for computing the mapping may be found at
+link:$$https://proj.org/operations/projections/sinu.html$$[https://proj.org/operations/projections/sinu.html]
 and
 link:$$http://geotiff.maptools.org/proj_list/sinusoidal.html$$[http://geotiff.maptools.org/proj_list/sinusoidal.html].
 Detailed formulas can be found in <<Snyder>>, pages 243-248.
@@ -353,8 +363,8 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Formulas for the mapping and its inverse along with notes on using the **`PROJ.4`** software package for doing the calcuations may be found at
-link:$$http://proj4.org/projections/stere.html$$[http://proj4.org/projections/stere.html]
+__Notes:__:: Formulas for the mapping and its inverse along with notes on using the **`PROJ`** software package for doing the calcuations may be found at
+link:$$https://proj.org/operations/projections/stere.html$$[https://proj.org/operations/projections/stere.html]
 and
 link:$$http://geotiff.maptools.org/proj_list/stereographic.html$$[http://geotiff.maptools.org/proj_list/stereographic.html].
 See the section "Polar stereographic" for the special case when the projection origin is one of the poles.
@@ -377,8 +387,8 @@ __Map parameters:__::
 
 __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates are identified by the **`standard_name`** attribute values **`projection_x_coordinate`** and **`projection_y_coordinate`** respectively.
 
-__Notes:__:: Formulas for the mapping and its inverse along with notes on using the **`PROJ.4`** software package for doing the calcuations may be found at
-link:$$http://proj4.org/projections/tmerc.html$$[http://proj4.org/projections/tmerc.html]
+__Notes:__:: Formulas for the mapping and its inverse along with notes on using the **`PROJ`** software package for doing the calcuations may be found at
+link:$$https://proj.org/operations/projections/tmerc.html$$[https://proj.org/operations/projections/tmerc.html]
 and
 link:$$http://geotiff.maptools.org/proj_list/transverse_mercator.html$$[http://geotiff.maptools.org/proj_list/transverse_mercator.html].
 
@@ -408,8 +418,8 @@ __Notes:__:: A general description of vertical perspective projection is
 given in <<Snyder>>, pages 169-181.
 
 +
-The corresponding projection in PROJ.4 is nsper.
-This should not be confused with the PROJ.4 geos projection.
+The corresponding projection in PROJ is nsper.
+This should not be confused with the PROJ geos projection.
 
 
 In the following table the "Type" values are **S** for string and **N** for numeric.


### PR DESCRIPTION
See issue #253 for discussion of these changes in [Appendix F: Grid Mappings](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#appendix-grid-mappings) of the CF Conventions:

* Replace `PROJ.4` by `PROJ`.
* Replace `http://proj4.org/projections/` by `https://proj.org/operations/projections/`.
* Some projections are missing a link to the corresponding description in the PROJ-manual. Add these links.