### PR TITLE
Chap 34 ancillary quality flags

### DIFF
--- a/ch03.adoc
+++ b/ch03.adoc
@@ -107,7 +107,7 @@ When one data variable provides metadata about the individual values of another 
 
 [[instrument-data-ex]]
 [caption="Example 3.2. "]
-.Instrument data
+.Ancillary instrument data
 ====
 
 ----
@@ -125,10 +125,47 @@ When one data variable provides metadata about the individual values of another 
 
 ----
 
-
 ====
 
 
+Alternatively, **`ancillary_variables`** may be used as status flags indicating the operational status of an instrument producing the data or as quality flags indicating the results of a quality control test, or some other quantitative quality assessment, performed against the measurements contained in the source variable.  In these cases, the flag variable will include a standard name that differs from that of the source variable and indicates the specific type of flag the variable represents.
+
+The standard names table includes many names intended to be used in this situation, both general names meant to be used to flexibly represent any type of status or quality assessment, as well as names for specific quality control tests commonly applied to geophysical phenomena timeseries data.  Several examples are listed below:
+
+.Sample flag variable standard names:
+- **`status_flag`** and **`quality_flag`**: general flag categories for instrument status or quality assessment
+- **`climatology_test_quality_flag`**, **`flat_line_test_quality_flag`**, **`gap_test_quality_flag`**, **`spike_test_quality_flag`**: a subset of standard name flags used to indicate the results of commonly-used geophysical timeseries data quality control tests (consult the standard names table for a full list of published flags)
+- **`aggregate_quality_flag`**: flag indicating an aggregate summary of all quality tests performed on the data variable, both automated and manual (i.e. a master quality flag for a particular variable)
+
+The following example illustrates the use of three of these flags to represent two independent quality control tests and an aggregate flag that combines the results of the two tests.
+
+[[quality-flag-ex]]
+[caption="Example 3.2.1 "]
+.Ancillary quality flag data
+====
+
+----
+float salinity(time, z);
+        salinity:units = "1";
+        salinity:long_name = "Salinity";
+        salinity:standard_name = "sea_water_practical_salinity";
+        salinity:ancillary_variables = "salinity_qc_generic salinity_qc_flat_line_test salinity_qc_agg";
+
+    int salinity_qc_generic(time, z);
+        salinity_qc_generic:long_name = "Salinity Generic QC Process Flag";
+        salinity_qc_generic:standard_name = "quality_flag";
+
+    int salinity_qc_flat_line_test(time, z);
+        salinity_qc_flat_line_test:long_name = "Salinity Flat Line Test Flag";
+        salinity_qc_flat_line_test:standard_name = "flat_line_test_quality_flag";
+
+    int salinity_qc_agg(time, z);
+        salinity_qc_agg:long_name = "Salinity Aggregate Flag";
+        salinity_qc_agg:standard_name = "aggregate_quality_flag";
+----
+Note that the ancillary variables in this example are simplified to exclude  **`flag_values`**, **`flag_masks`** and
+**`flag_meanings`** attributes described in <<flags>> that they would ordinarily require
+====
 
 
 [[flags, Section 3.5, "Flags"]]
@@ -175,18 +212,8 @@ attribute with a value containing current_speed_qc.
 
 ====
 
-The **`flag_masks`** and **`flag_meanings`** attributes describe a
-number of independent Boolean conditions using bit field notation by
-setting unique bits in each **`flag_masks`** value.  **`The
-flag_masks`** attribute is the same type as the variable to which it is
-attached, and contains a list of values matching unique bit fields.  The
-**`flag_meanings`** attribute is defined as above, one for each
-**`flag_masks`** value.  A flagged condition is identified by performing
-a bitwise AND of the variable value and each **`flag_masks`** value; a
-non-zero result indicates a **`true`** condition.  Thus, any or all of
-the flagged conditions may be **`true`**, depending on the variable bit
-settings. The following example illustrates the use of **`flag_masks`**
-to express six sensor status conditions.
+The flag_masks and flag_meanings attributes describe a number of independent Boolean conditions using bit field notation by setting unique bits in each flag_masks value. The flag_masks attribute is the same type as the variable to which it is attached, and contains a list of values matching unique bit fields. The flag_meanings attribute is defined as above, one for each flag_masks value. A flagged condition is identified by performing a bitwise AND of the variable value and each flag_masks value; a non-zero result indicates a true condition. Thus, any or all of the flagged conditions may be true, depending on the variable bit settings. The following example illustrates the use of flag_masks to express six sensor status conditions.
+
 
 [[flag-variable-flag-masks-ex]]
 [caption="Example 3.4. "]
@@ -196,6 +223,7 @@ to express six sensor status conditions.
 ----
   byte sensor_status_qc(time, depth, lat, lon) ;
     sensor_status_qc:long_name = "Sensor Status" ;
+    sensor_status_qc:standard_name = "status_flag" ;
     sensor_status_qc:_FillValue = 0b ;
     sensor_status_qc:valid_range = 1b, 63b ;
     sensor_status_qc:flag_masks = 1b, 2b, 4b, 8b, 16b, 32b ;
@@ -250,6 +278,7 @@ conditions and one enumerated status code.
 ----
   byte sensor_status_qc(time, depth, lat, lon) ;
     sensor_status_qc:long_name = "Sensor Status" ;
+    sensor_status_qc:standard_name = "status_flag" ;
     sensor_status_qc:_FillValue = 0b ;
     sensor_status_qc:valid_range = 1b, 15b ;
     sensor_status_qc:flag_masks = 1b, 2b, 12b, 12b, 12b ;

--- a/ch03.adoc
+++ b/ch03.adoc
@@ -140,7 +140,7 @@ The standard names table includes many names intended to be used in this situati
 The following example illustrates the use of three of these flags to represent two independent quality control tests and an aggregate flag that combines the results of the two tests.
 
 [[quality-flag-ex]]
-[caption="Example 3.2.1 "]
+[caption="Example 3.3 "]
 .Ancillary quality flag data
 ====
 
@@ -163,6 +163,7 @@ float salinity(time, z);
         salinity_qc_agg:long_name = "Salinity Aggregate Flag";
         salinity_qc_agg:standard_name = "aggregate_quality_flag";
 ----
+
 Note that the ancillary variables in this example are simplified to exclude  **`flag_values`**, **`flag_masks`** and
 **`flag_meanings`** attributes described in <<flags>> that they would ordinarily require
 ====
@@ -191,7 +192,7 @@ illustrates the use of flag values to express a speed quality with an
 enumerated status code.
 
 [[flag-variable-flag-values-ex]]
-[caption="Example 3.3. "]
+[caption="Example 3.4. "]
 .A flag variable, using **`flag_values`**
 ====
 
@@ -216,7 +217,7 @@ The flag_masks and flag_meanings attributes describe a number of independent Boo
 
 
 [[flag-variable-flag-masks-ex]]
-[caption="Example 3.4. "]
+[caption="Example 3.5. "]
 .A flag variable, using **`flag_masks`**
 ====
 
@@ -235,11 +236,11 @@ The flag_masks and flag_meanings attributes describe a number of independent Boo
 
 ====
 
-A variable with standard name of `region`, `area_type` or any other standard name which requires string-valued values from a defined list may use flags together with `flag_values` and `flag_meanings` attributes to record the translation to the string values. Example 3.5 illustrates this using integer flag values for a variable with standard name `region` and `flag_values` selected from the link:$$http://cfconventions.org/Data/cf-standard-names/docs/standardized-region-names.html$$[standardized region names] (see section 6.1.1).
+A variable with standard name of `region`, `area_type` or any other standard name which requires string-valued values from a defined list may use flags together with `flag_values` and `flag_meanings` attributes to record the translation to the string values. The following example illustrates this using integer flag values for a variable with standard name `region` and `flag_values` selected from the link:$$http://cfconventions.org/Data/cf-standard-names/docs/standardized-region-names.html$$[standardized region names] (see section 6.1.1).
 
 
 [[region-variable-flag-values-ex]]
-[caption="Example 3.5. "]
+[caption="Example 3.6. "]
 .A region variable, using **`flag_values`**
 ====
 
@@ -271,7 +272,7 @@ number of status conditions with different **`flag_values`**.  The
 conditions and one enumerated status code.
 
 [[flag-variable-flag-masks-flag-values-ex]]
-[caption="Example 3.6. "]
+[caption="Example 3.7. "]
 .A flag variable, using **`flag_masks`** and **`flag_values`**
 ====
 

--- a/toc-extra.adoc
+++ b/toc-extra.adoc
@@ -15,6 +15,7 @@ F.1. <<table-grid-mapping-attributes>>
 [%hardbreaks]
 3.1. <<use-of-standard-name-ex>>
 3.2. <<instrument-data-ex>>
+3.2.1. <<quality-flag-ex>>
 3.3. <<flag-variable-flag-values-ex>>
 3.4. <<flag-variable-flag-masks-ex>>
 3.5. <<region-variable-flag-values-ex>>

--- a/toc-extra.adoc
+++ b/toc-extra.adoc
@@ -15,11 +15,11 @@ F.1. <<table-grid-mapping-attributes>>
 [%hardbreaks]
 3.1. <<use-of-standard-name-ex>>
 3.2. <<instrument-data-ex>>
-3.2.1. <<quality-flag-ex>>
-3.3. <<flag-variable-flag-values-ex>>
-3.4. <<flag-variable-flag-masks-ex>>
-3.5. <<region-variable-flag-values-ex>>
-3.6. <<flag-variable-flag-masks-flag-values-ex>>
+3.3. <<quality-flag-ex>>
+3.4. <<flag-variable-flag-values-ex>>
+3.5. <<flag-variable-flag-masks-ex>>
+3.6. <<region-variable-flag-values-ex>>
+3.7. <<flag-variable-flag-masks-flag-values-ex>>
 4.1. <<latitude-axis-ex>>
 4.2. <<longitude-axis-ex>>
 4.3. <<atm-sigma-coord-ex>>


### PR DESCRIPTION
Replaces: #235

See issue #216 for discussion of these changes, specifically in [this comment](https://github.com/cf-convention/cf-conventions/issues/216#issuecomment-564107540) suggesting adding to the CF documentation usage examples for status_flag, quality_flag, and related QC flag standard names proposed in #216.

This PR includes the following:

- adds to Chapter 3.4 new text describing usage of ancillary variables as status/quality flags, and a new Example 3.3 illustrating their use
- adds `status_flag` attributes to Example 3.5 as suggested in #216 and earlier discussions in the CF mailing list surrounding the addition of `quality_flag`.  See [this thread](http://mailman.cgd.ucar.edu/pipermail/cf-metadata/2019/020995.html) in the CF list archives for related discussion. 