### PR TITLE
Removing unnecessary dimensions

### DIFF
--- a/apph.adoc
+++ b/apph.adoc
@@ -76,7 +76,6 @@ If the time series instances have the same number of elements and the time value
    dimensions:
      station = 10 ;  // measurement locations
      time = UNLIMITED ;
-     name_strlen = 23 ;
 
    variables:
      float humidity(station,time) ;
@@ -298,7 +297,6 @@ When the time series have different lengths and the data values for entire time 
    dimensions:
       station = 23 ;
       obs = 1234 ;
-      name_strlen = 23 ;
 
    variables:
       float lon(station) ; 
@@ -719,7 +717,6 @@ When storing multiple trajectories in the same file, and the number of elements 
    dimensions:
       obs = 1000 ;
       trajectory = 77 ;
-      name_strlen = 23 ;
 
    variables:
       string trajectory(trajectory) ;
@@ -838,7 +835,6 @@ When the number of elements for each trajectory varies, and one can control the 
    dimensions:
       obs = 3443;
       trajectory = 77 ;
-      name_strlen = 23 ;
    
    variables:
       string trajectory(trajectory) ;
@@ -977,7 +973,6 @@ When storing time series of profiles at multiple stations in the same data varia
       station = 22 ;
       profile = 3002 ;
       z = 42 ;
-      name_strlen = 23 ;
    
    variables:
       float lon(station) ; 
@@ -1152,7 +1147,6 @@ When the number of profiles and levels for each station varies, one can use a ra
       obs = UNLIMITED ;
       profiles = 1420 ;
       stations = 42;
-      name_strlen = 23 ;
    
    variables:
       float lon(station) ; 


### PR DESCRIPTION
In some examples where only `string` type is been used, there is a dimension `name_strlen` which it's unnecesary. 
