### PR TITLE
Allow CRS WKT to represent the CRS without requiring reader to compare with grid mapping parameters

### DIFF
--- a/cf-conventions.adoc
+++ b/cf-conventions.adoc
@@ -37,6 +37,7 @@ include::toc-extra.adoc[]
 * Charlie Zender, University of California, Irvine
 * Daniel Lee, EUMETSAT
 * David Hassell, NCAS and University of Reading
+* Alan D. Snow, Corteva Agriscience
 
 Many others have contributed to the development of CF through their participation in discussions about proposed changes.
 

--- a/ch05.adoc
+++ b/ch05.adoc
@@ -477,23 +477,20 @@ For example, a file has two coordinate variables, lon and lat, and a grid mappin
 
 The **`crs_wkt`** attribute is intended to act as a _supplement_ to other single-property CF grid
 mapping attributes (as described in Appendix F); it is not intended to replace those attributes. If
-data producers omit the single-property grid mapping attributes in favour of the compound
-**`crs_wkt`** attribute, software which cannot interpret **`crs_wkt`** will be unable to use the
-grid_mapping information. Therefore the CRS should be described as thoroughly as possible with the
-single-property attributes as well as by **`crs_wkt`**.
+data producers omit the single-property grid mapping attributes in favour of the **`crs_wkt`**
+attribute, software which cannot interpret **`crs_wkt`** will be unable to use the grid_mapping
+information. Therefore the CRS should be described as thoroughly as possible with the single-property
+grid mapping attributes as well as by **`crs_wkt`**.
 
-There will be occasions when a given CRS property value is duplicated in both a single-property grid
-mapping attribute and the **`crs_wkt`** attribute. In such cases the onus is on data producers to
-ensure that the property values are consistent. However, in those situations where two values of a
-given property are different, If both crs_wkt and grid mapping attributes exist, the attributes
-must be the same and grid mapping parameters should always be completed as fully as possible.
-As such, information from either one (or both) may be read in by the user without needing to
-check both. However, in those situations where the two values of a given property are different,
-the CRS information cannot be interpreted accurately and users should inform the provider so
-the issue can be addressed. For example, if the semi-major axis length of the ellipsoid is
-defined by the grid mapping attribute **`semi_major_axis`** and also by the **`crs_wkt`**
-attribute (via the WKT **`SPHEROID[...]`** element), the value of this attribute cannot be
-interpreted accurately. Naturally if the two values are equal then no ambiguity arises.
+In cases where CRS property values can be represented by both a single-property grid mapping attribute
+and the **`crs_wkt`** attribute, the grid mapping should be provided, and if both are provided, the
+onus is on data producers to ensure that their property values are consistent. Therefore information
+from either one (or both) may be read in by the user without needing to check both. However, if the
+two values of a given property are different, the CRS information cannot be interpreted accurately
+and users should inform the provider so the issue can be addressed. For example, if the semi-major
+axis length of the ellipsoid defined by the grid mapping attribute **`semi_major_axis`** disagrees
+with the **`crs_wkt`** attribute (via the **`WKT SPHEROID[…​]`** element), the value of this attribute
+cannot be interpreted accurately. Naturally if the two values are equal then no ambiguity arises.
 
 Likewise, in those cases where the value of a CRS WKT element should be used consistently across the
 CF-netCDF community (names of projections and projection parameters, for example) then, the values

--- a/ch05.adoc
+++ b/ch05.adoc
@@ -485,11 +485,15 @@ single-property attributes as well as by **`crs_wkt`**.
 There will be occasions when a given CRS property value is duplicated in both a single-property grid
 mapping attribute and the **`crs_wkt`** attribute. In such cases the onus is on data producers to
 ensure that the property values are consistent. However, in those situations where two values of a
-given property are different, then the value specified by the single-property attribute shall take
-precedence. For example, if the semi-major axis length of the ellipsoid is defined by the grid
-mapping attribute **`semi_major_axis`** and also by the **`crs_wkt`** attribute (via the WKT
-**`SPHEROID[...]`** element) then the former, being the more specific attribute, takes
-precedence. Naturally if the two values are equal then no ambiguity arises.
+given property are different, If both crs_wkt and grid mapping attributes exist, the attributes
+must be the same and grid mapping parameters should always be completed as fully as possible.
+As such, information from either one (or both) may be read in by the user without needing to
+check both. However, in those situations where the two values of a given property are different,
+the CRS information cannot be interpreted accurately and users should inform the provider so
+the issue can be addressed. For example, if the semi-major axis length of the ellipsoid is
+defined by the grid mapping attribute **`semi_major_axis`** and also by the **`crs_wkt`**
+attribute (via the WKT **`SPHEROID[...]`** element), the value of this attribute cannot be
+interpreted accurately. Naturally if the two values are equal then no ambiguity arises.
 
 Likewise, in those cases where the value of a CRS WKT element should be used consistently across the
 CF-netCDF community (names of projections and projection parameters, for example) then, the values

--- a/history.adoc
+++ b/history.adoc
@@ -254,3 +254,6 @@ node coordinate variables to be one of the dimensions of the data variable.
 
 .2 June 2020
 . link:$$https://github.com/cf-convention/cf-conventions/issues/259$$[Issue #259]: Clarify geostationary projection items
+
+.6 July 2020
+. link:$$https://github.com/cf-convention/cf-conventions/issues/222$$[Issue #222]: Allow CRS WKT to represent the CRS without requiring reader to compare with grid mapping parameters.


### PR DESCRIPTION
The three weeks have gone by without complaint, so I am moving forward with this change.

# Release checklist
- [x] Closes #222 (See this issue for discussion of these changes)
- [x] Authors updated in `cf-conventions.adoc`?
- [ ] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [x] `history.adoc` up to date?
- [ ] Conformance document up-to-date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then `master` always is a draft for the next version.
