### PR TITLE
Conformance clarification for  region name/area types

### DIFF
--- a/conformance.adoc
+++ b/conformance.adoc
@@ -201,8 +201,9 @@ name modifier.
 name table.
 * The legal values for the standard name modifier are contained in
 Appendix C, Standard Name Modifiers.
-* If a variable has a **`standard_name`** of **`region`** or **`area_type`**, it must have value(s) 
-from the permitted list.
+* If a variable has a **`standard_name`** of **`region`** or **`area_type`**, it must
+either have value(s) from the permitted list or, if flags are being used, the
+**`flag_meanings`** attribute must contain values from the permitted list.
 
 *Recommendataions:*
 


### PR DESCRIPTION
Clarification to conformance document for region names/area_types to allow use of flag_values and flag_meanings as per discussion in #198.  This was a PR that got missed before the conformance document was moved into the cf-conventions repository.

See issue #198 for discussion of these changes.

# Release checklist
- [x] Authors updated in `cf-conventions.adoc`?
- [x] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [ ] `history.adoc` up to date?
- [x] Conformance document up-to-date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then `master` always is a draft for the next version.
