### PR TITLE
Add support for variables of type string to conformance doc

### DIFF
--- a/conformance.adoc
+++ b/conformance.adoc
@@ -201,8 +201,9 @@ name modifier.
 name table.
 * The legal values for the standard name modifier are contained in
 Appendix C, Standard Name Modifiers.
-* If a variable has a **`standard_name`** of **`region`** or **`area_type`**, it must have value(s) 
-from the permitted list.
+* If a variable has a **`standard_name`** of **`region`** or **`area_type`**, it must
+either have value(s) from the permitted list or, if flags are being used, the
+**`flag_meanings`** attribute must contain values from the permitted list.
 
 *Recommendataions:*
 

--- a/conformance.adoc
+++ b/conformance.adoc
@@ -29,7 +29,8 @@ material required for completeness or clarity.
 
 *Requirements:*
 
-* CF attributes that take string values must be 1D character arrays.
+* CF attributes that take string values must be 1D character arrays or single
+atomic strings.
 
 [[section-1]]
 
@@ -364,10 +365,10 @@ blank separated list of variable names. All specified variable names
 must exist in the file.
 * The dimensions of each auxiliary coordinate must be a subset of the
 dimensions of the variable they are attached to, with two exceptions.
-First, a label variable which will have a trailing dimension for the
-maximum string length. Second a ragged array (Chapter 9, Discrete
-sampling geometries and Appendix H) uses special, more indirect, methods
-to connect the data and coordinates. +
+First, a label variable of type **`char`** will have a trailing dimension
+for the maximum string length.
+Second, a ragged array (Chapter 9, Discrete sampling geometries and Appendix H)
+uses special, more indirect, methods to connect the data and coordinates.
 
 *Recommendations:*
 
@@ -420,11 +421,14 @@ the CRS WKT specification described in reference [OGC_CTS].
 
 *Requirements:*
 
-* A variable of character type that is named by a **`coordinates`** attribute
-is a label variable. This variable must have one or two dimensions. The
-trailing (CDL order) or sole dimension is for the maximum string length.
-If there are two dimensions, leading dimension (CDL order) must match
-one of those of the data variable.
+* A string variable that is named by a **`coordinates`** attribute is a label
+variable.
+If the variable is of type **`string`** it must have at most one dimension,
+which must match one of those of the data variable.
+If the variable is of type **`char`** it must have one or two dimensions, where
+the trailing (CDL order) or sole dimension is for the maximum string length.
+If there are two dimensions, the leading dimension (CDL order) must match one
+of those of the data variable.
 
 [[section-17]]
 
@@ -493,17 +497,23 @@ or more blank separated word lists, each with the form
 ....
 dim1: [dim2: [dim3: ...]] method [where type1 [over type2]] [within|over days|years] [(comment)]
 ....
-where brackets indicate optional words. The valid values for **`dim1`** [**`dim2`**
-[**`dim3`** ...] ] are the names of dimensions of the data variable, names of
-scalar coordinate variables of the data variable, valid standard names,
-or the word **`area`**. The valid values of **`method`** are contained in Appendix E. The valid values
-for **`type1`** are the name of a string-valued auxiliary  
-or scalar coordinate variable with a **`standard_name`** of **`area_type`**, or any
-string value allowed for a variable of **`standard_name`** of **`area_type`**. If
-**`type2`** is a string-valued auxiliary coordinate variable, it is not
-allowed to have a leading dimension (the number of strings) of more than
-one. When the method refers to a climatological time axis, the suffixes
-for within and over may be appended.
+where brackets indicate optional words.
+The valid values for **`dim1`** [**`dim2`** [**`dim3`** ...] ] are the names of
+dimensions of the data variable, names of scalar coordinate variables of the
+data variable, valid standard names, or the word **`area`**.
+The valid values of **`method`** are contained in Appendix E.
+The valid values for **`type1`** are the name of a string-valued auxiliary  or
+scalar coordinate variable with a **`standard_name`** of **`area_type`**, or
+any string value allowed for a variable of **`standard_name`** of
+**`area_type`**.
+If **`type2`** is a string-valued auxiliary coordinate variable, it must be
+sized to contain a single string.
+If it is a variable of type **`string`**, it must be scalar or one-dimensional
+with a length of one.
+If it is a variable of type **`char`**, it must be one-dimensional or
+two-dimensional with a leading dimension (the number of strings) of length one.
+When the method refers to a climatological time axis, the suffixes for within
+and over may be appended.
 
 * A given dimension name may only occur once in a **`cell_methods`** string.
 An exception is a climatological time dimension.

--- a/conformance.adoc
+++ b/conformance.adoc
@@ -202,9 +202,8 @@ name modifier.
 name table.
 * The legal values for the standard name modifier are contained in
 Appendix C, Standard Name Modifiers.
-* If a variable has a **`standard_name`** of **`region`** or **`area_type`**, it must
-either have value(s) from the permitted list or, if flags are being used, the
-**`flag_meanings`** attribute must contain values from the permitted list.
+* If a variable has a **`standard_name`** of **`region`** or **`area_type`**, it must have value(s) 
+from the permitted list.
 
 *Recommendataions:*
 


### PR DESCRIPTION
See issue #139 for discussion of these changes.

This was a missed PR in the conformance repo before it was moved into the cf-conventions repo  (cf-convention/Conformance#7)


# Release checklist
- [ ] Authors updated in `cf-conventions.adoc`?
- [ ] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [ ] `history.adoc` up to date?
- [x] Conformance document up-to-date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then `master` always is a draft for the next version.
