### PR TITLE
Post-release update of version number in draft documents to "1.10 draft"

### DIFF
--- a/cf-conventions.adoc
+++ b/cf-conventions.adoc
@@ -1,6 +1,6 @@
 = NetCDF Climate and Forecast (CF) Metadata Conventions
 Brian{nbsp}Eaton; Jonathan{nbsp}Gregory; Bob{nbsp}Drach; Karl{nbsp}Taylor; Steve{nbsp}Hankin; Jon{nbsp}Blower; John{nbsp}Caron; Rich{nbsp}Signell; Phil{nbsp}Bentley; Greg{nbsp}Rappa; Heinke{nbsp}Höck; Alison{nbsp}Pamment; Martin{nbsp}Juckes; Martin{nbsp}Raspaud; Randy{nbsp}Horne; Timothy{nbsp}Whiteaker; David{nbsp}Blodgett; Charlie{nbsp}Zender; Daniel{nbsp}Lee; David{nbsp}Hassell; Alan{nbsp}D.{nbsp}Snow; Tobias{nbsp}Kölling; Dave{nbsp}Allured; Aleksandar{nbsp}Jelenak; Anders{nbsp}Meier{nbsp}Soerensen; Lucile{nbsp}Gaultier; Sylvain{nbsp}Herlédan
-Version 1.9, 10 September, 2021
+Version 1.10 draft, 10 September, 2021
 :doctype: book
 :pdf-folio-placement: physical
 :sectanchors:

--- a/conformance.adoc
+++ b/conformance.adoc
@@ -1,5 +1,5 @@
-﻿[[cf-conformance-requirements-and-recommendations-1.9]]
-== CF Conformance Requirements and Recommendations 1.9
+﻿[[cf-conformance-requirements-and-recommendations-1.10-draft]]
+== CF Conformance Requirements and Recommendations 1.10 draft
 
 
 * The following is a list of requirements and recommendations for a CF


### PR DESCRIPTION
I think we missed this in the release process. Or maybe we haven't done this in the past.

I didn't change the date next to the version number at the top of the conventions document.