### PR TITLE
Update two mentions of 1.8 to 1.9

### DIFF
--- a/ch01.adoc
+++ b/ch01.adoc
@@ -117,7 +117,7 @@ vertical dimension:: A dimension of a netCDF variable that has an associated ver
 
 No variable or dimension names are standardized by this convention. Instead we follow the lead of the NUG and standardize only the names of attributes and some of the values taken by those attributes. Variable or dimension names can either be a single variable name or a path to a variable. The overview provided in this section will be followed with more complete descriptions in following sections. <<attribute-appendix>> contains a summary of all the attributes used in this convention.
 
-Files using this version of the CF Conventions must set the NUG defined attribute **`Conventions`** to contain the string value "**`CF-1.8`**" to identify datasets that conform to these conventions.
+Files using this version of the CF Conventions must set the NUG defined attribute **`Conventions`** to contain the string value "**`CF-1.9`**" to identify datasets that conform to these conventions.
 
 The general description of a file's contents should be contained in the following attributes: **`title`** , **`history`** , **`institution`** , **`source`** , **`comment`** and **`references`** ( <<description-of-file-contents>> ). For backwards compatibility with COARDS none of these attributes is required, but their use is recommended to provide human readable documentation of the file contents.
 

--- a/ch02.adoc
+++ b/ch02.adoc
@@ -159,7 +159,7 @@ This standard describes many attributes (some mandatory, others optional), but a
 [[identification-of-conventions]]
 ==== Identification of Conventions
 
-Files that follow this version of the CF Conventions must indicate this by setting the NUG defined global attribute **`Conventions`** to a string value that contains "**`CF-1.8`**".
+Files that follow this version of the CF Conventions must indicate this by setting the NUG defined global attribute **`Conventions`** to a string value that contains "**`CF-1.9`**".
 The Conventions version number contained in that string can be used to find the web based versions of this document are from the link:$$http://cfconventions.org/$$[netCDF Conventions web page].
 Subsequent versions of the CF Conventions will not make invalid a compliant usage of this or earlier versions of the CF terms and forms.
 


### PR DESCRIPTION
Two locations mention that the value "CF-1.8" MUST be used for conforming datasets. Naively I assumed that these values should be updated "1.9". (Looking at previous commits like https://github.com/cf-convention/cf-conventions/commit/b6c65807a7dbf1eb78d6f711cd079296d7f43b63 this looks to be the case.)