### PR TITLE
Release procedure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,3 +61,6 @@ The person who merges the pull request also closes the issue.
 If subsequent discussion is required after the pull request has been merged then a new issue should be raised, rather than reopening the closed issue.
 An issue may be closed without the merging of a pull request if the change was not accepted by the community.
 In this case the issue may be reopened for further discussion at a later date.
+
+Whether or not a discussion concludes with a change of the Conventions, when closing an issue, the moderator should note in the final comment any users who have contributed significantly enough to warrant addition to the [CF Conventions Contributors List](https://cfconventions.org/conventions_contributors.html).
+

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -68,6 +68,11 @@ latest release in GitHub.)
    * `latest.md`
    * `requirements-and-recommendations.md`
    * `software.md`
+   
+## Update Conventions Contributors list
+Check the issues that have been closed since the last release.
+When closing an issue, the moderator will have mentioned any users whose contributions have been substantial enough to warrant addition to the [list of contributors](https://cfconventions.org/conventions_contributors.html).
+Add new users who need to be mentioned to `conventions_contributors.md`.
  
 ## Announce the release
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,79 @@
+# Release process for a new version of the CF conventions
+
+### 1. Documents
+
+* Check that the version (e.g. `1.10`) in `cf-conventions.adoc` is correct.
+
+* Set the release date in `cf-conventions.adoc`.
+
+* Check that the version in `conformance.adoc` is correct.
+
+* Check that the history in `history.adoc` is up to date. Every Pull
+  Request merged to the convention document should be
+  referenced. Check that all merged Pull Requests that contributed to
+  the new version have the appropriate GitHub Milestone attached to
+  them.
+
+
+### 2. Repository
+
+When all Pull Requests have been merged:
+
+* Tag the master branch with the new version (e.g. `v1.10.0`).
+
+* Create a new "Latest release" that contains a link to the Pull
+  Requests that contributed to the new version. Include a link to the
+  contributing the Pull Requests labelled with the appropriate GitHub
+  milestone.
+
+(It is possible to combine these two items whilst setting up the new
+latest release in GitHub.)
+
+* Get the new documents from the Artefacts of the latest GitHub Actions:
+
+  * `cf-conventions.html`
+  * `cf-conventions.pdf`
+  * `images/*`
+  * `conformance.html`
+  * `conformance.pdf`
+
+### 3. Set new draft version
+
+* Set the new *next* version in `cf-conventions.adoc`, and change the
+  release date to "draft"
+
+* Set the new *next* version in `conformance.adoc`.
+
+## Move to the cf-convention.github.io repository
+
+### 4. At cf-convention.github.io, add the release documents
+
+* Commit the new release documents into the `Data` folder as follows:
+   
+  * `Data/cf-conventions/cf-conventions-<vn>/cf-conventions.html`
+  * `Data/cf-conventions/cf-conventions-<vn>/cf-conventions.pdf`
+  * `Data/cf-conventions/cf-conventions-<vn>/images/*`
+  * `Data/cf-documents/requirements-recommendations/conformance-<vn>.html`
+     
+   where `<vn>` is replaced with the new version (e.g. `1.10`). Ensure
+   that the PDF file is not stored with LFS. These documents are
+   available as Artefacts from the latest GitHub Actions run in the
+   cf-conventions repository.
+
+### 5. At cf-convention.github.io, update website links and headings for the new version
+
+* The following files need updating (although be aware that changes
+  to the web site may introduce new links in other files, in which
+  case this list should be updated as part of the release):
+  
+   * `documents.md`
+   * `faq.md`
+   * `latest.md`
+   * `requirements-and-recommendations.md`
+   * `software.md`
+ 
+## Announce the release
+
+* Wait until all changes are visible via the web site, and then
+  announce the release on `cf-convention/discuss/issues`. There may
+  already be a open issue in which to do this.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,9 +3,8 @@ Complete the following steps in the order presented.
 
 ## Documents
 
-* Check that the version (e.g. `1.10`) in `cf-conventions.adoc` is correct.
-* Set the release date in `cf-conventions.adoc`.
-* Check that the version in `conformance.adoc` is correct.
+* Set the release date in `cf-conventions.adoc` by editing the line containing the text `Version {current-version}`
+
 * Check that all merged Pull Requests that contributed to the new
   version have the correct GitHub Milestone
   (https://github.com/cf-convention/cf-conventions/milestones)
@@ -15,22 +14,18 @@ Complete the following steps in the order presented.
 * Check that the history in `history.adoc` is up to date. Every Pull
   Request merged to the convention document should be referenced.
 
-### 2. Repository
+### Repository
 
-* Tag the master branch with the new version (e.g. `v1.10.0`).
+* "Draft a new release" at https://github.com/cf-convention/cf-conventions/releases
 
-* Create a new "Latest release" that contains a link to the Pull
-  Requests that contributed to the new version:
-  https://github.com/cf-convention/cf-conventions/releases. Include a
-  link to the list of contributing the Pull Requests that are labelled
-  with the new version's GitHub milestone. This link is found via
-  https://github.com/cf-convention/cf-conventions/milestones, from
-  where you select the version, and then view the "Closed" items.
+  * "Choose a tag" for the new version on the  `main` branch (e.g. `v1.10.0`)
 
-(It is possible to combine these two items whilst setting up the new
-latest release in GitHub.)
+  * In the release description, create a link called "List of pull requests that contributed to CF-\<version\>" that points to the the list of contributing the Pull Requests that are labelled with the new version's GitHub milestone.
+  This link is found via https://github.com/cf-convention/cf-conventions/milestones, from where you select the version, and then view the "Closed" items.
 
-* Get the new documents from the Artefacts of the latest GitHub Actions, found at https://github.com/cf-convention/cf-conventions/tree/gh-pages:
+  * "Publish" the release, which will trigger the GitHub Actions that generate the documents to be copied over to the website repository (https://github.com/cf-convention/cf-convention.github.io)
+
+* Get the new documents from the "Artifacts" section of the latest GitHub Actions run (https://github.com/cf-convention/cf-conventions/actions), saving them locally:
 
   * `cf-conventions.html`
   * `cf-conventions.pdf`
@@ -38,14 +33,9 @@ latest release in GitHub.)
   * `conformance.html`
   * `conformance.pdf`
 
-## Set new draft version
-* Set the new *next* version in `cf-conventions.adoc`, and change the
-  release date to "draft"
-* Set the new *next* version in `conformance.adoc`.
-
 ## Move to the https://github.com/cf-convention/cf-convention.github.io repository
 
-### 4. At cf-convention.github.io, add the release documents
+### Add the release documents
 
 * Commit the new release documents into the `Data` folder as follows:
    
@@ -54,15 +44,11 @@ latest release in GitHub.)
   * `Data/cf-conventions/cf-conventions-<vn>/images/*`
   * `Data/cf-documents/requirements-recommendations/conformance-<vn>.html`
 
-* Ensure that the PDF file is not stored with LFS. These documents are
-   available as Artefacts from the latest GitHub Actions run in the
-   cf-conventions repository.
+* Ensure that the PDF file is not stored with LFS. Note the these documents are found from the "Artifacts" seciotn of the latest GitHub Actions run in the cf-conventions repository.
 
-## At cf-convention.github.io, update website links and headings for the new version
+### Update website links and headings for the new version
 
-* The following files need updating (although be aware that changes
-  to the web site may introduce new links in other files, in which
-  case this list should be updated as part of the release):
+* The following files need updating (although be aware that changes to the web site may introduce new links in other files, in which case this list should be updated as part of the release):
    * `documents.md`
    * `faq.md`
    * `latest.md`
@@ -76,7 +62,5 @@ Add new users who need to be mentioned to `conventions_contributors.md`.
  
 ## Announce the release
 
-* Wait until all changes are visible via the web site, and then
-  announce the release on the `discuss` repo issue tracker:
-  https://github.com/cf-convention/discuss/issues/new. (Note: There
-  may already be a open issue in which to do this.)
+* Wait until all changes are visible via the web site, and then announce the release on the `discuss` repo issue tracker: https://github.com/cf-convention/discuss/issues.
+  (Note: There may already be a open issue in which to do this.)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,23 +8,26 @@
 
 * Check that the version in `conformance.adoc` is correct.
 
-* Check that the history in `history.adoc` is up to date. Every Pull
-  Request merged to the convention document should be
-  referenced. Check that all merged Pull Requests that contributed to
-  the new version have the appropriate GitHub Milestone attached to
-  them.
+* Check that all merged Pull Requests that contributed to the new
+  version have the correct GitHub Milestone
+  (https://github.com/cf-convention/cf-conventions/milestones)
+  attached to them - the milestone has the same name as the new
+  version (e.g. `1.10`).
 
+* Check that the history in `history.adoc` is up to date. Every Pull
+  Request merged to the convention document should be referenced.
 
 ### 2. Repository
-
-When all Pull Requests have been merged:
 
 * Tag the master branch with the new version (e.g. `v1.10.0`).
 
 * Create a new "Latest release" that contains a link to the Pull
-  Requests that contributed to the new version. Include a link to the
-  contributing the Pull Requests labelled with the appropriate GitHub
-  milestone.
+  Requests that contributed to the new version:
+  https://github.com/cf-convention/cf-conventions/releases. Include a
+  link to the list of contributing the Pull Requests that are labelled
+  with the new version's GitHub milestone. This link is found via
+  https://github.com/cf-convention/cf-conventions/milestones, from
+  where you select the version, and then view the "Closed" items.
 
 (It is possible to combine these two items whilst setting up the new
 latest release in GitHub.)
@@ -44,7 +47,7 @@ latest release in GitHub.)
 
 * Set the new *next* version in `conformance.adoc`.
 
-## Move to the cf-convention.github.io repository
+## Move to the https://github.com/cf-convention/cf-convention.github.io repository
 
 ### 4. At cf-convention.github.io, add the release documents
 
@@ -75,5 +78,6 @@ latest release in GitHub.)
 ## Announce the release
 
 * Wait until all changes are visible via the web site, and then
-  announce the release on `cf-convention/discuss/issues`. There may
-  already be a open issue in which to do this.
+  announce the release on the `discuss` repo issue tracker:
+  https://github.com/cf-convention/discuss/issues/new. (Note: There
+  may already be a open issue in which to do this.)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,7 +30,8 @@ Complete the following steps in the order presented.
 (It is possible to combine these two items whilst setting up the new
 latest release in GitHub.)
 
-* Get the new documents from the Artefacts of the latest GitHub Actions:
+* Get the new documents from the Artefacts of the latest GitHub Actions, found at https://github.com/cf-convention/cf-conventions/tree/gh-pages:
+
   * `cf-conventions.html`
   * `cf-conventions.pdf`
   * `images/*`


### PR DESCRIPTION
Superseded by #498

~See issue #371 for discussion of these changes.~

# Release checklist
- [NA ] Authors updated in `cf-conventions.adoc`?
- [NA] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [NA] `history.adoc` up to date?
- [NA] Conformance document up-to-date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then `master` always is a draft for the next version.
