### PR TITLE
delete incorrect missing_data attributes of time coordinate variables in two examples

### DIFF
--- a/apph.adoc
+++ b/apph.adoc
@@ -207,7 +207,6 @@ When the intention of a data variable is to contain only a single time series, t
           time:standard_name = "time";
           time:long_name = "time of measurement" ;
           time:units = "days since 1970-01-01 00:00:00" ;
-          time:missing_value = -999.9;
       float humidity(time) ;
           humidity:standard_name = “specific_humidity” ;
           humidity:coordinates = "time lat lon alt station_name" ;
@@ -268,7 +267,6 @@ While an idealized time series is defined at a single, stable point location, th
           time:standard_name = "time";
           time:long_name = "time of measurement" ;
           time:units = "days since 1970-01-01 00:00:00" ;
-          time:missing_value = -999.9;
       float humidity(time) ;
           humidity:standard_name = “specific_humidity” ;
           humidity:coordinates = "time lat lon alt precise_lon precise_lat station_name" ;

--- a/history.adoc
+++ b/history.adoc
@@ -7,6 +7,7 @@
 
 === Version 1.10 (current working draft)
 
+* {issues}162[Issue #162]: Delete incorrect missing_data attributes of time coordinate variables in two examples
 * {issues}345[Issue #345]: Reformat the revision history
 * {issues}349[Issue #349]: Delete unnecessary Conventions attribute in two examples
 * {issues}129[Issue #129]: timeSeries featureType with a forecast/reference time dimension?


### PR DESCRIPTION
See issue #162 for discussion of these changes.

# Release checklist
- [NA] Authors updated in `cf-conventions.adoc`?
- [NA] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [Y] `history.adoc` up to date?
- [NA] Conformance document up-to-date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then `master` always is a draft for the next version.
