### PR TITLE
Add missing history items for CF-1.10

### DIFF
--- a/history.adoc
+++ b/history.adoc
@@ -7,9 +7,12 @@
 
 === Version 1.10 (current working draft)
 
-* {issues}162[Issue #162]: Delete incorrect missing_data attributes of time coordinate variables in two examples
+* {pull-requests}378[Pull request #378]: Fixed missing semicolon in example 7.16
+* {issues}366[Issue #366]: Clarify the intention of standard names
+* {issues}352[Issue #352]: Correct errors in description of lossy compression by coordinate subsampling
 * {issues}345[Issue #345]: Reformat the revision history
 * {issues}349[Issue #349]: Delete unnecessary Conventions attribute in two examples
+* {issues}162[Issue #162]: Delete incorrect missing_data attributes of time coordinate variables in two examples
 * {issues}129[Issue #129]: timeSeries featureType with a forecast/reference time dimension?
 
 === Version 1.9 (10 September 2021)


### PR DESCRIPTION
No associated issue - just adding to the history changes that had not been recorded before.

# Release checklist
- NA Authors updated in `cf-conventions.adoc`?
- NA Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [x] `history.adoc` up to date?
- NA Conformance document up-to-date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then `master` always is a draft for the next version.
