### PR TITLE
Fix escaping in single sourcing of version

### DIFF
--- a/.github/workflows/adoc_build.yml
+++ b/.github/workflows/adoc_build.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Set "final" tag
       if: github.event_name == 'release'
       run: |
-        echo "FINAL_TAG='-a final'" >> "$GITHUB_ENV"
+        echo "FINAL_TAG=-a final" >> "$GITHUB_ENV"
     # Build cf-conventions.html using the Analog-inc asciidoctor-action
     - name: Build cf-conventions.html
       uses: Analog-inc/asciidoctor-action@v1.2
@@ -76,7 +76,7 @@ jobs:
     - name: Set "final" tag
       if: github.event_name == 'release'
       run: |
-        echo "FINAL_TAG='-a final'" >> "$GITHUB_ENV"
+        echo "FINAL_TAG=-a final" >> "$GITHUB_ENV"
     # Build conformance.html using the Analog-inc asciidoctor-action
     - name: Build conformance.html
       uses: Analog-inc/asciidoctor-action@v1.2


### PR DESCRIPTION
See issue #388 for discussion of these changes.

# Release checklist
- [ ] Authors updated in `cf-conventions.adoc`?
- [ ] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [ ] `history.adoc` up to date?
- [ ] Conformance document up-to-date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then `master` always is a draft for the next version.
