### PR TITLE
Delete "on a spherical Earth" from the definition of the `latitude_longitude` grid mapping in Appendix F

### DIFF
--- a/appf.adoc
+++ b/appf.adoc
@@ -200,7 +200,7 @@ grid_mapping_name = latitude_longitude
 
 ----
 
-This grid mapping defines the canonical 2D geographical coordinate system based upon latitude and longitude coordinates on a spherical Earth.
+This grid mapping defines the canonical 2D geographical coordinate system based upon latitude and longitude coordinates.
 It is included so that the figure of the Earth can be described.
 
 __Map parameters:__:: None.


### PR DESCRIPTION
See issues https://github.com/cf-convention/cf-conventions/issues/410 and https://github.com/cf-convention/discuss/issues/188 for discussion of these changes