### PR TITLE
Always use "strictly monotonic" when describing coordinate variables

### DIFF
--- a/appd.adoc
+++ b/appd.adoc
@@ -384,7 +384,7 @@ The `nsigma` parameter is deprecated and optional in `formula_terms`; if supplie
 
 The `standard_name` for the vertical coordinate variable is `ocean_sigma_z_coordinate`.
 This variable should contain `sigma(k)*depth_c` for the layers where `sigma` is defined and `zlev(k)` for the other layers, with units of length.
-The layers must be arranged so that the vertical coordinate variable contains a monotonic set of indicative values for the heights of the levels relative to the datum, either increasing or decreasing, and the direction must be indicated by the `positive` attribute, in the usual way for a vertical coordinate variable.
+The layers must be arranged so that the vertical coordinate variable contains a strictly monotonic set of indicative values for the heights of the levels relative to the datum, either increasing or decreasing, and the direction must be indicated by the `positive` attribute, in the usual way for a vertical coordinate variable.
 
 ===  Ocean double sigma coordinate
 

--- a/apph.adoc
+++ b/apph.adoc
@@ -76,7 +76,7 @@ The global attribute **`featureType={rdquo}timeSeries{rdquo}`** (case-insensitiv
 ==== Orthogonal multidimensional array representation of time series
 
 If the time series instances have the same number of elements and the time values are identical for all instances, you may use the orthogonal multidimensional array representation.
-This has either a one-dimensional coordinate variable, time(time), provided the time values are ordered monotonically, or a one-dimensional auxiliary coordinate variable, time(o), where o is the element dimension.
+This has either a one-dimensional coordinate variable, time(time), provided the time values are in strict monotonically increasing order, or a one-dimensional auxiliary coordinate variable, time(o), where o is the element dimension.
 In the former case, listing the time variable in the **`coordinates`** attributes of the data variables is optional.
 
 [[example-h.2]]
@@ -463,7 +463,7 @@ The global attribute **`featureType={rdquo}profile{rdquo}`** (case-insensitive) 
 ==== Orthogonal multidimensional array representation of profiles
 
 If the profile instances have the same number of elements and the vertical coordinate values are identical for all instances, you may use the orthogonal multidimensional array representation.
-This has either a one-dimensional coordinate variable, z(z), provided the vertical coordinate values are ordered monotonically, or a one-dimensional auxiliary coordinate variable, alt(o), where o is the element dimension.
+This has either a one-dimensional coordinate variable, z(z), provided the vertical coordinate values are in strict monotonic order, or a one-dimensional auxiliary coordinate variable, alt(o), where o is the element dimension.
 In the former case, listing the vertical coordinate variable in the **coordinates** attributes of the data variables is optional.
 
 [[example-h.8, Example H.8, "Atmospheric sounding profiles for a common set of vertical coordinates stored in the orthogonal multidimensional array representation."]]
@@ -1101,7 +1101,7 @@ The pressure(i,p,o), temperature(i,p,o), and humidity(i,p,o) data for element o 
 Any of the three dimensions could be the netCDF unlimited dimension, if it might be useful to be able enlarge it.
 
 If all of the profiles at any given station have the same set of vertical coordinates values, the vertical auxiliary coordinate variable could be dimensioned alt(station, z).
-If all the profiles have the same set of vertical coordinates, the vertical auxiliary coordinate variable could be one-dimensional alt(z), or replaced by a one-dimensional coordinate variable z(z), provided the values are ordered monotonically.
+If all the profiles have the same set of vertical coordinates, the vertical auxiliary coordinate variable could be one-dimensional alt(z), or replaced by a one-dimensional coordinate variable z(z), provided the values are in strict monotonic order.
 In the latter case, listing the vertical coordinate variable in the coordinates attribute is optional.
 
 If the profiles are taken at all stations at the same set of times, the time auxiliary coordinate variable could be one-dimensional time(profile), or replaced by a one-dimensional coordinate variable time(time), where the size of the time dimension is now equal to the number of profiles at each station.
@@ -1211,7 +1211,7 @@ If there is only one station in the data variable, there is no need for the stat
     :featureType = "timeSeriesProfile";
 ----
 The pressure(p,o), temperature(p,o), and humidity(p,o) data for element o of profile p are associated with the coordinate values time(p), alt(p,o), lat, and lon.
-If all the profiles have the same set of vertical coordinates, the vertical auxiliary coordinate variable could be one-dimensional alt(z), or replaced by a one-dimensional coordinate variable z(z), provided the values are ordered monotonically.
+If all the profiles have the same set of vertical coordinates, the vertical auxiliary coordinate variable could be one-dimensional alt(z), or replaced by a one-dimensional coordinate variable z(z), provided the values are in strict monotonic order.
 In the latter case, listing the vertical coordinate variable in the coordinates attribute is optional.
 ====
 
@@ -1384,7 +1384,7 @@ The pressure(i,p,o), temperature(i,p,o), and humidity(i,p,o) data for element o 
 Any of the three dimensions could be the netCDF unlimited dimension, if it might be useful to be able enlarge it.
 
 If all of the profiles along any given trajectory have the same set of vertical coordinates values, the vertical auxiliary coordinate variable could be dimensioned alt(trajectory, z).
-If all the profiles have the same set of vertical coordinates, the vertical auxiliary coordinate variable could be one-dimensional alt(z), or replaced by a one-dimensional coordinate variable z(z), provided the values are ordered monotonically.
+If all the profiles have the same set of vertical coordinates, the vertical auxiliary coordinate variable could be one-dimensional alt(z), or replaced by a one-dimensional coordinate variable z(z), provided the values are in strict monotonic order.
 In the latter case, listing the vertical coordinate variable in the coordinates attribute is optional.
 
 If the profiles are taken along all the trajectories at the same set of times, the time auxiliary coordinate variable could be one-dimensional time(profile), or replaced by a one-dimensional coordinate variable time(time), where the size of the time dimension is now equal to the number of profiles along each trajectory.
@@ -1455,7 +1455,7 @@ If there is only one trajectory in the data variable, there is no need for the t
     :featureType = "trajectoryProfile";
 ----
 The pressure(p,o), temperature(p,o), and humidity(p,o) data for element o of profile p are associated with the coordinate values time(p), alt(p,o), lat(p), and lon(p).
-If all the profiles have the same set of vertical coordinates, the vertical auxiliary coordinate variable could be one-dimensional alt(z), or replaced by a one-dimensional coordinate variable z(z), provided the values are ordered monotonically.
+If all the profiles have the same set of vertical coordinates, the vertical auxiliary coordinate variable could be one-dimensional alt(z), or replaced by a one-dimensional coordinate variable z(z), provided the values are in strict monotonic order.
 In the latter case, listing the vertical coordinate variable in the coordinates attribute is optional.
 ====
 

--- a/ch01.adoc
+++ b/ch01.adoc
@@ -84,8 +84,8 @@ cell:: A region in one or more dimensions whose boundary can be described by a s
 The term __interval__ is sometimes used for one-dimensional cells.
 
 coordinate variable:: We use this term precisely as it is defined in the
-link:$$http://www.unidata.ucar.edu/software/netcdf/docs/netcdf_data_set_components.html#coordinate_variables$$[NUG section on coordinate variables].
-It is a one-dimensional variable with the same name as its dimension [e.g., **`time(time)`**], and it is defined as a numeric data type with values that are ordered monotonically.
+link:$$https://docs.unidata.ucar.edu/nug/current/best_practices.html#bp_Coordinate-Systems$$[NUG section on coordinate variables].
+It is a one-dimensional variable with the same name as its dimension [e.g., **`time(time)`**], and it is defined as a numeric data type with values in strict monotonic order (all values are different and either increasing or decreasing).
 Missing values are not allowed in coordinate variables.
 
 grid mapping variable:: A variable used as a container for attributes that define a specific grid mapping.

--- a/ch01.adoc
+++ b/ch01.adoc
@@ -85,7 +85,7 @@ The term __interval__ is sometimes used for one-dimensional cells.
 
 coordinate variable:: We use this term precisely as it is defined in the
 link:$$https://docs.unidata.ucar.edu/nug/current/best_practices.html#bp_Coordinate-Systems$$[NUG section on coordinate variables].
-It is a one-dimensional variable with the same name as its dimension [e.g., **`time(time)`**], and it is defined as a numeric data type with values in strict monotonic order (all values are different and either increasing or decreasing).
+It is a one-dimensional variable with the same name as its dimension [e.g., **`time(time)`**], and it is defined as a numeric data type with values in strict monotonic order (all values are different, and they are arranged in either consistently increasing or consistently decreasing order).
 Missing values are not allowed in coordinate variables.
 
 grid mapping variable:: A variable used as a container for attributes that define a specific grid mapping.

--- a/ch09.adoc
+++ b/ch09.adoc
@@ -32,16 +32,16 @@ Details and examples of storage of each of these feature types are provided in A
 | **point** 2+| a single data point (having no implied coordinate relationship to other points)
 |||       data(i) | x(i) y(i)  t(i) | <<point-data>>
 
-| **timeSeries** 2+| a series of data points at the same spatial location with monotonically increasing times
+| **timeSeries** 2+| a series of data points at the same spatial location with time values in strict monotonically increasing order
 |||      data(i,o) | x(i) y(i) t(i,o) | <<time-series-data>>
 
-| **trajectory** 2+| a series of data points along a path through space with monotonically increasing times
+| **trajectory** 2+| a series of data points along a path through space with time values in strict monotonically increasing order
 |||        data(i,o)    | x(i,o) y(i,o) t(i,o) | <<trajectory-data>>
 
 | **profile** 2+| an ordered set of data points along a vertical line at a fixed horizontal position and fixed time
 |||        data(i,o)    | x(i) y(i) z(i,o) t(i) | <<profile-data>>
 
-| **timeSeriesProfile** 2+| a series of profile features at the same horizontal position with monotonically increasing times
+| **timeSeriesProfile** 2+| a series of profile features at the same horizontal position with time values in strict monotonically increasing order
 |||        data(i,p,o)      | x(i) y(i) z(i,p,o) t(i,p) | <<time-series-profiles>>
 
 | **trajectoryProfile** 2+| a series of profile features located at points ordered along a trajectory

--- a/history.adoc
+++ b/history.adoc
@@ -7,6 +7,7 @@
 
 === Working version (most recent first)
 
+* {issues}423[Issue #423]: Always use "strictly monotonic" when describing coordinate variables
 * {issues}420[Issue #420]: Add List of Figures
 * {issues}210[Issue #210]: Correct errors in examples H9-H11
 * {issues}374[Issue #374]: Clarify rules for packing and unpacking in Section 8.1


### PR DESCRIPTION
Update text in convention document to consistently use "strictly monotonic" instead of "monotonic" when describing coordinate variables.

See issue #423 for discussion of these changes.

# Release checklist
- [ ] Authors updated in `cf-conventions.adoc`?
- [ ] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [x] `history.adoc` up to date?
- [ ] Conformance document up-to-date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then `main` always is a draft for the next version.
