### PR TITLE
Fixing CF 8.1 refering int types

### DIFF
--- a/ch08.adoc
+++ b/ch08.adoc
@@ -30,7 +30,7 @@ The units of a variable should be representative of the unpacked data.
 This standard is more restrictive than the NUG with respect to the use of the **`scale_factor`** and **`add_offset`** attributes; ambiguities and precision problems related to data type conversions are resolved by these restrictions.
 If the **`scale_factor`** and **`add_offset`** attributes are of the same data type as the associated variable, the unpacked data is assumed to be of the same data type as the packed data.
 However, if the **`scale_factor`** and **`add_offset`** attributes are of a different data type from the variable (containing the packed data) then the unpacked data should match the type of these attributes, which must both be of type **`float`** or both be of type **`double`**.
-An additional restriction in this case is that the variable containing the packed data must be of type **`byte`**, **`short`** or **`int`**.
+An additional restriction in this case is that the variable containing the packed data must be of an integer type (see <<data-types>>).
 It is not advised to unpack an **`int`** into a **`float`** as there is a potential precision loss.
 
 When data to be packed contains missing values the attributes that indicate missing values (**`_FillValue`**, **`valid_min`**, **`valid_max`**, **`valid_range`**) must be of the same data type as the packed data.


### PR DESCRIPTION
See issue cf-convention/discuss#202 for discussion of these changes.

Complements #244 #294 #243 

# Release checklist
- [ ] Authors updated in `cf-conventions.adoc`?
- [ ] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [ ] `history.adoc` up to date?
- [ ] Conformance document up-to-date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then `main` always is a draft for the next version.
