### PR TITLE
Cf conventions deployment position

### DIFF
--- a/apph.adoc
+++ b/apph.adoc
@@ -238,7 +238,7 @@ When the intention of a data variable is to contain only a single time series, t
 ====
 
 While an idealized time series is defined at a single, stable point location, there are examples of time series, such as cabled ocean surface mooring measurements, in which the precise position of the observations varies slightly from a nominal fixed point. It is quite common that the deployment position of a station changes after maintenance or repositioning after it drifts. 
-In the following example we show how the spatial positions of such a time series should be encoded in CF.
+In the following example we show how the spatial positions of such a time series should be encoded in CF. In addition, this example shows how lossless compression by gathering <<compression-by-gathering>> has been applied to the deployment coordinate variables, which otherwise would contain a lot of missing or repetitive data.
 Note that although this example shows only a single time series, the technique is applicable to all of the representations.
 
 

--- a/apph.adoc
+++ b/apph.adoc
@@ -242,8 +242,8 @@ In the following example we show how the spatial positions of such a time series
 Note that although this example shows only a single time series, the technique is applicable to all of the representations.
 
 
-[[example-h.5]]
-[caption="Example H.5. "]
+[[example-h.5a]]
+[caption="Example H.5a. "]
 .A single timeseries with time-varying deviations from a nominal point spatial location
 ====
 ----
@@ -296,6 +296,77 @@ Note that although this example shows only a single time series, the technique i
 
    attributes:
           :featureType = "timeSeries";
+----
+====
+
+It is quite common that the deployment position of a station changes after maintenance or repositioning after it drifts. In the following example we show how these changes in the deployment position can be encoded in CF. Note that although this example shows only a single time series, the technique is applicable to all of the representations.
+
+
+[[example-h.5b]]
+[caption="Example H.5b. "]
+.A single timeseries with time-varying deviations from a nominal point spatial location that also can change after redeployments
+====
+----
+   dimensions:
+      time = 100233 ;
+      name_strlen = 23 ;
+      deployment = 5 ;
+
+   variables:
+      float lon ;
+          lon:standard_name = "longitude";
+          lon:long_name = "station longitude";
+          lon:units = "degrees_east";
+          lon:axis = “X”;
+      float lat ;
+          lat:standard_name = "latitude";
+          lat:long_name = "station latitude" ;
+          lat:units = "degrees_north" ;
+          lat: axis = “Y” ;
+      float precise_lon (time);
+          precise_lon:standard_name = "longitude";
+          precise_lon:long_name = "station longitude";
+          precise_lon:units = "degrees_east";
+      float precise_lat (time);
+          precise_lat:standard_name = "latitude";
+          precise_lat:long_name = "station latitude" ;
+          precise_lat:units = "degrees_north" ;
+      float deploy_lon (deployment);
+          deploy_lon:standard_name = "deployment_longitude";
+          deploy_lon:long_name = station longitude";
+          deploy_lon:units = "degrees_east";
+      float deploy_lat (deployment);
+          deploy_lat:standard_name = "deployment_latitude";
+          deploy_lat:long_name = station latitude";
+          deploy_lat:units = "degrees_north";
+      int deployment (deployment) ;
+          deployment:long_name = "index of the first time after (re)deployment" ;
+          deployment:compress="time";
+      float alt ;
+          alt:long_name = "vertical distance above the surface" ;
+          alt:standard_name = "height" ;
+          alt:units = "m";
+          alt:positive = "up";
+          alt:axis = "Z";
+      char station_name(name_strlen) ;
+          station_name:long_name = "station name" ;
+          station_name:cf_role = "timeseries_id";
+      double time(time) ;
+          time:standard_name = "time";
+          time:long_name = "time of measurement" ;
+          time:units = "days since 1970-01-01 00:00:00" ;
+      float humidity(time) ;
+          humidity:standard_name = “specific_humidity” ;
+          humidity:coordinates = "time lat lon alt precise_lon precise_lat deploy_lon deploy_lat station_name" ;
+          humidity:_FillValue = -999.9f;
+      float temp(time) ;
+          temp:standard_name = “air_temperature” ;
+          temp:units = "Celsius" ;
+          temp:coordinates = "time lat lon alt precise_lon precise_lat deploy_lon deploy_lat station_name" ;
+          temp:_FillValue = -999.9f;
+
+   attributes:
+          :featureType = "timeSeries";
 ----
 ====
 

--- a/apph.adoc
+++ b/apph.adoc
@@ -237,74 +237,14 @@ When the intention of a data variable is to contain only a single time series, t
 ----
 ====
 
-While an idealized time series is defined at a single, stable point location, there are examples of time series, such as cabled ocean surface mooring measurements, in which the precise position of the observations varies slightly from a nominal fixed point.
+While an idealized time series is defined at a single, stable point location, there are examples of time series, such as cabled ocean surface mooring measurements, in which the precise position of the observations varies slightly from a nominal fixed point. It is quite common that the deployment position of a station changes after maintenance or repositioning after it drifts. 
 In the following example we show how the spatial positions of such a time series should be encoded in CF.
 Note that although this example shows only a single time series, the technique is applicable to all of the representations.
 
 
-[[example-h.5a]]
-[caption="Example H.5a. "]
+[[example-h.5]]
+[caption="Example H.5. "]
 .A single timeseries with time-varying deviations from a nominal point spatial location
-====
-----
-   dimensions:
-      time = 100233 ;
-      name_strlen = 23 ;
-
-   variables:
-      float lon ;
-          lon:standard_name = "longitude";
-          lon:long_name = "station longitude";
-          lon:units = "degrees_east";
-          lon:axis = “X”;
-      float lat ;
-          lat:standard_name = "latitude";
-          lat:long_name = "station latitude" ;
-          lat:units = "degrees_north" ;
-          lat: axis = “Y” ;
-      float precise_lon (time);
-          precise_lon:standard_name = "longitude";
-          precise_lon:long_name = "station longitude";
-          precise_lon:units = "degrees_east";
-      float precise_lat (time);
-          precise_lat:standard_name = "latitude";
-          precise_lat:long_name = "station latitude" ;
-          precise_lat:units = "degrees_north" ;
-      float alt ;
-          alt:long_name = "vertical distance above the surface" ;
-          alt:standard_name = "height" ;
-          alt:units = "m";
-          alt:positive = "up";
-          alt:axis = "Z";
-      char station_name(name_strlen) ;
-          station_name:long_name = "station name" ;
-          station_name:cf_role = "timeseries_id";
-
-      double time(time) ;
-          time:standard_name = "time";
-          time:long_name = "time of measurement" ;
-          time:units = "days since 1970-01-01 00:00:00" ;
-      float humidity(time) ;
-          humidity:standard_name = “specific_humidity” ;
-          humidity:coordinates = "time lat lon alt precise_lon precise_lat station_name" ;
-          humidity:_FillValue = -999.9f;
-      float temp(time) ;
-          temp:standard_name = “air_temperature” ;
-          temp:units = "Celsius" ;
-          temp:coordinates = "time lat lon alt precise_lon precise_lat station_name" ;
-          temp:_FillValue = -999.9f;
-
-   attributes:
-          :featureType = "timeSeries";
-----
-====
-
-It is quite common that the deployment position of a station changes after maintenance or repositioning after it drifts. In the following example we show how these changes in the deployment position can be encoded in CF. Note that although this example shows only a single time series, the technique is applicable to all of the representations.
-
-
-[[example-h.5b]]
-[caption="Example H.5b. "]
-.A single timeseries with time-varying deviations from a nominal point spatial location that also can change after redeployments
 ====
 ----
    dimensions:

--- a/cf-conventions.adoc
+++ b/cf-conventions.adoc
@@ -45,6 +45,7 @@ include::toc-extra.adoc[]
 * Anders Meier Soerensen, EUMETSAT
 * Lucile Gaultier, OceanDataLab
 * Sylvain Herlédan, OceanDataLab
+* Fernando Manzano, Puertos del Estado
 
 Many others have contributed to the development of CF through their participation in discussions about proposed changes.
 

--- a/ch05.adoc
+++ b/ch05.adoc
@@ -13,9 +13,10 @@ This is the only method of associating dimensions with coordinates that is suppo
 Any longitude, latitude, vertical or time coordinate which depends on more than one spatiotemporal dimension must be identified by the **`coordinates`** attribute of the data variable.
 The value of the **`coordinates`** attribute is __a blank separated list of the names of auxiliary coordinate variables__.
 There is no restriction on the order in which the auxiliary coordinate variables appear in the **`coordinates`** attribute string.
-The dimensions of an auxiliary coordinate variable must be a subset of the dimensions of the variable with which the coordinate is associated, with two exceptions.
+The dimensions of an auxiliary coordinate variable must be a subset of the dimensions of the variable with which the coordinate is associated, with three exceptions.
 First, string-valued coordinates (<<labels>>) will have a dimension for maximum string length if the coordinate variable has a type of **`char`** rather than a type of **`string`**.
-Second, in the ragged array representations of data (<<discrete-sampling-geometries>>), special methods are needed to connect the data and coordinates.
+Second, if the data variable has a list dimension resulting from lossless compression by gathering (<<compression-by-gathering>>), its auxiliary coordinate variables may have any of the dimensions named by the compress attribute of the list variable.
+Third, in the ragged array representations of data (<<discrete-sampling-geometries>>), special methods are needed to connect the data and coordinates.
 
 We recommend that the name of a multidimensional coordinate variable should not match the name of any of its dimensions because that precludes supplying a coordinate variable for the dimension.
 This practice also avoids potential bugs in applications that determine coordinate variables by only checking for a name match between a dimension and a variable and not checking that the variable is one dimensional.

--- a/ch08.adoc
+++ b/ch08.adoc
@@ -52,6 +52,7 @@ Compression and uncompression are executed by looping over the list.
 
 The list is stored as the coordinate variable for the compressed axis of the data variable.
 Thus, the list variable and its dimension have the same name.
+If any auxiliary coordinate variable has all the dimensions to be compressed, adjacent and in the same order as in the data variable, and if the auxiliary coordinate variable has missing data at all the points which are to be eliminated from the data variable, then the affected dimensions can optionally be replaced by the list dimension for the auxiliary coordinate variable just as for the data variable.
 The list variable has a string attribute **`compress`**, __containing a blank-separated list of the dimensions which were affected by the compression in the order of the CDL declaration of the uncompressed array__.
 The presence of this attribute identifies the list variable as such.
 The list, the original dimensions and coordinate variables (including boundary variables), and the compressed variables with all the attributes of the uncompressed variables are written to the netCDF file.
@@ -105,6 +106,7 @@ variables:
 This information implies that the salinity field should be uncompressed to an array with dimensions `(depth,lat,lon)`.
 ====
 
+In <<example-h.5>>, two auxiliary coordinate variables are compressed as described in this section, although their data variable is not.
 
 [[compression-by-coordinate-subsampling, Section 8.3, "Lossy Compression by Coordinate Subsampling"]]
 === Lossy Compression by Coordinate Subsampling

--- a/ch08.adoc
+++ b/ch08.adoc
@@ -50,7 +50,7 @@ In the compressed array, the axes to be compressed are all replaced by a single 
 The wanted points appear along this dimension in the same order they appear in the uncompressed array, with the unwanted points skipped over.
 Compression and uncompression are executed by looping over the list.
 
-The list is stored as the coordinate variable for the compressed axis of the data array.
+The list is stored as the coordinate variable for the compressed axis of the data variable.
 Thus, the list variable and its dimension have the same name.
 The list variable has a string attribute **`compress`**, __containing a blank-separated list of the dimensions which were affected by the compression in the order of the CDL declaration of the uncompressed array__.
 The presence of this attribute identifies the list variable as such.

--- a/ch09.adoc
+++ b/ch09.adoc
@@ -564,7 +564,7 @@ Similarly, although an idealized time series exists at a fixed lat-long position
 
 CF Discrete Geometries provides a mechanism to encode both the nominal and the precise positions, while retaining the semantics of the idealized feature type.
 Only the set of coordinates which are regarded as the nominal (default or preferred) positions should be indicated by the attribute **`axis`**, which should be assigned string values to indicate the orientations of the axes (**`X`**, **`Y`**, **`Z`**, or **`T`**).
-See example A9.2.3.2.
+See <<example-h.5>> (a single timeseries with time-varying deviations from a nominal point spatial location): 
 Auxiliary coordinate variables containing the nominal and the precise positions should be listed in the relevant **`coordinates`** attributes of data variables.
 In orthogonal representations the nominal positions could be  coordinate variables, which do not need to be listed in the **`coordinates`** attribute, rather than auxiliary coordinate variables.
 

--- a/conformance.adoc
+++ b/conformance.adoc
@@ -276,9 +276,10 @@ If the **`calendar`** attribute is given a non-standard value, then the attribut
 * A coordinate variable must not have the **`_FillValue`** or **`missing_value`** attributes.
 * The type of the **`coordinates`** attribute is a string whose value is a blank separated list of variable names.
 All specified variable names must exist in the file.
-* The dimensions of each auxiliary coordinate must be a subset of the dimensions of the variable they are attached to, with two exceptions.
+* The dimensions of each auxiliary coordinate must be a subset of the dimensions of the variable they are attached to, with three exceptions.
 First, a label variable of type **`char`** will have a trailing dimension for the maximum string length.
-Second, a ragged array (Chapter 9, Discrete sampling geometries and Appendix H) uses special, more indirect, methods to connect the data and coordinates.
+Second, if the data variable to which the auxiliary coordinate variable is attached has a dimension whose coordinate variable has a **`compress`** attribute, the auxiliary coordinate variable may have any of the dimensions named by that attribute.
+Third, a ragged array (Chapter 9, Discrete sampling geometries and Appendix H) uses special, more indirect, methods to connect the data and coordinates.
 
 *Recommendations:*
 

--- a/history.adoc
+++ b/history.adoc
@@ -4,6 +4,7 @@
 
 [[revhistory, Revision History]]
 == Revision History
+* {issues}428[Issue #428]: Recording deployment positions
 * {pull-requests}408[Pull request #408]: Deleted a sentence on "rotated Mercator" under `Oblique Mercator` grid mapping in Appendix F
 * {issues}260[Issue #260]: Clarify use of dimensionless units
 * {issues}410[Issue #410]: Delete "on a spherical Earth" from the definition of the `latitude_longitude` grid mapping in Appendix F 


### PR DESCRIPTION
See issue #428 for discussion of these changes.

It is quite common that the deployment position of a station changes after maintenance or repositioning after it drifts. Example H.5. "A single timeseries with time-varying deviations from a nominal point spatial location" has been extended to show how these deployments can be encoded in CF. Lossless compression by gathering is applied to the deployment coordinate variables, which otherwise would contain a lot of missing or repetitive data. 
- Appendix H has been modified to extend Example H.5
- Section 5 and conformance modified to add a new exception to consider also dimensions in the compress attribute of the auxiliary coordinate.
- Section 8.2 modified to add more information and reference Example H.5
- Section 9 updated to correct a reference to Example H.5

# Release checklist
- [x] Authors updated in `cf-conventions.adoc`?
- [x] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [x] `history.adoc` up to date?
- [x] Conformance document up-to-date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then `master` always is a draft for the next version.
