### PR TITLE
Correct link to NUG in the bibliography

### DIFF
--- a/bibliography.adoc
+++ b/bibliography.adoc
@@ -9,7 +9,7 @@ Sponsored by the "Cooperative Ocean/Atmosphere Research Data Service," a NOAA/un
 Federal Geographic Data Committee, FGDC-STD-001-1998.
 - [[[IEEE_754]]]  link:$$https://ieeexplore.ieee.org/servlet/opac?punumber=8766227$$[IEEE Standard for Floating-Point Arithmetic], in __IEEE Std 754-2019 (Revision of IEEE 754-2008)__, vol., no., pp.1-84, 22 July 2019, doi: 10.1109/IEEESTD.2019.8766229.
 - [[[NetCDF]]]  link:$$http://www.unidata.ucar.edu/netcdf/index.html$$[NetCDF Software Package].  UNIDATA Program Center of the University Corporation for Atmospheric Research.
-- [[[NUG]]]  link:$$http://www.unidata.ucar.edu/software/netcdf/docs/user_guide.html$$[The NetCDF User's Guide] for NetCDF version 4.4.1.1.
+- [[[NUG]]]  link:$$https://docs.unidata.ucar.edu/nug/current/index.html$$[The NetCDF User's Guide].
 - [[[OGC_WKT-CRS]]]  link:$$http://www.opengeospatial.org/standards/wkt-crs$$[OGC Well-known text representation of coordinate reference systems].
 OGC document 12-063. 1st May 2015.
 - [[[OGP-EPSG]]]  link:$$http://www.epsg.org$$[OGP Surveying &amp; Positioning Committee] and link:$$http://www.epsg-registry.org$$[EPSG Geodetic Parameter Registry].

--- a/history.adoc
+++ b/history.adoc
@@ -4,6 +4,7 @@
 
 [[revhistory, Revision History]]
 == Revision History
+* {issues}437[Issue #437]: Correct link to NUG in the bibliography
 * {issues}428[Issue #428]: Recording deployment positions
 * {issues}430[Issue #430]: Clarify the function of the `cf_role` attribute
 * {pull-requests}408[Pull request #408]: Deleted a sentence on "rotated Mercator" under `Oblique Mercator` grid mapping in Appendix F


### PR DESCRIPTION
See [issue 437](https://github.com/cf-convention/cf-conventions/issues/437) for discussion of these changes.

# Release checklist
- [NA] Authors updated in `cf-conventions.adoc`?
- [NA] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [Y] `history.adoc` up to date?
- [NA] Conformance document up-to-date?