### PR TITLE
Correct link to Snyder and typo in the bibliography

### DIFF
--- a/bibliography.adoc
+++ b/bibliography.adoc
@@ -14,9 +14,9 @@ Federal Geographic Data Committee, FGDC-STD-001-1998.
 OGC document 12-063. 1st May 2015.
 - [[[OGP-EPSG]]]  link:$$http://www.epsg.org$$[OGP Surveying &amp; Positioning Committee] and link:$$http://www.epsg-registry.org$$[EPSG Geodetic Parameter Registry].
 - [[[OGP-EPSG_GN7_2]]]  link:$$http://www.epsg.org$$[OGP Surveying and Positioning Guidance Note 7, part 2: Coordinate Conversions and Transformations including Formulas].
-- [[[SCH02]]] C Schaer, D Leuenberger, and O Fuhrer. 2002. {ldquo} A new terrain-following vertical coordiante formulation for atmospheric prediction models {rdquo}.
+- [[[SCH02]]] C Schaer, D Leuenberger, and O Fuhrer. 2002. {ldquo} A new terrain-following vertical coordinate formulation for atmospheric prediction models {rdquo}.
 _Monthly Weather Review__.  130. 2459-2480.
-- [[[Snyder]]]  link:$$http://pubs.er.usgs.gov/usgspubs/pp/pp1395$$[Map Projections: A Working Manual]. USGS Professional Paper 1395.
+- [[[Snyder]]]  link:$$https://pubs.er.usgs.gov/publication/pp1395$$[Map Projections: A Working Manual]. USGS Professional Paper 1395.
 - [[[UDUNITS]]]  link:$$http://www.unidata.ucar.edu/software/udunits/$$[UDUNITS Software Package].  UNIDATA Program Center of the University Corporation for Atmospheric Research.
 - [[[W3C]]]  link:$$http://www.w3.org/$$[World Wide Web Consortium (W3C)].
 - [[[XML]]]  link:$$http://www.w3.org/TR/1998/REC-xml-19980210$$[Extensible Markup Language (XML) 1.0]. T. Bray, J. Paoli, and C.M. Sperberg-McQueen.  10 February 1998.

--- a/history.adoc
+++ b/history.adoc
@@ -4,6 +4,7 @@
 
 [[revhistory, Revision History]]
 == Revision History
+* {issues}391[Issue #391]: Correct link to Snyder and typo in the bibliography
 * {issues}437[Issue #437]: Correct link to NUG in the bibliography
 * {issues}428[Issue #428]: Recording deployment positions
 * {issues}430[Issue #430]: Clarify the function of the `cf_role` attribute


### PR DESCRIPTION
See issue [391](https://github.com/cf-convention/cf-conventions/issues/391) for discussion of these changes.

# Release checklist
- [NA] Authors updated in `cf-conventions.adoc`?
- [NA] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [Y] `history.adoc` up to date?
- [NA] Conformance document up-to-date?