### PR TITLE
add issue 406 to history

### DIFF
--- a/history.adoc
+++ b/history.adoc
@@ -4,6 +4,7 @@
 
 [[revhistory, Revision History]]
 == Revision History
+* {issues}406[Issue #406]: Remove duplicate section 8.2 in the conformance document
 * {issues}391[Issue #391]: Correct link to Snyder and typo in the bibliography
 * {issues}437[Issue #437]: Correct link to NUG in the bibliography
 * {issues}428[Issue #428]: Recording deployment positions


### PR DESCRIPTION
See issue #406 for discussion of these changes.

# Release checklist
- [NA] Authors updated in `cf-conventions.adoc`?
- [NA] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [Y] `history.adoc` up to date?
- [Y] Conformance document up-to-date?

[PR #407](https://github.com/cf-convention/cf-conventions/pull/407) did not update `history.adoc`. This PR adds a line to `history.adoc` for that purpose, and nothing else.