### PR TITLE
Update ch07.adoc, fix typo in example 7.12

### DIFF
--- a/ch07.adoc
+++ b/ch07.adoc
@@ -653,7 +653,7 @@ variables:
   double climatology_bounds(time,nv);
 data: // time coordinates translated to date/time format
   time="2008-1-16 6:00";
-  climatology_bounds="2007-12-1 6:00", "2000-8-2 6:00";
+  climatology_bounds="2007-12-1 6:00", "2008-3-1 6:00";
   threshold=0.;
 ----
 ====

--- a/history.adoc
+++ b/history.adoc
@@ -13,6 +13,7 @@
 * {pull-requests}408[Pull request #408]: Deleted a sentence on "rotated Mercator" under `Oblique Mercator` grid mapping in Appendix F
 * {issues}260[Issue #260]: Clarify use of dimensionless units
 * {issues}410[Issue #410]: Delete "on a spherical Earth" from the definition of the `latitude_longitude` grid mapping in Appendix F 
+* {issues}449[Issue #449]: Typo in end-date in Example 7.12
 
 === Version 1.10 (31 August 2022)
 


### PR DESCRIPTION
Fix end-date of 2007-2008 Winter to be in 2008 in Example 7.12.

See issue #XXX for discussion of these changes.

# Release checklist
- [ ] Authors updated in `cf-conventions.adoc`?
- [ ] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [ ] `history.adoc` up to date?
- [ ] Conformance document up-to-date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then `master` always is a draft for the next version.
