### PR TITLE
added examples to TOE; updated captions

### DIFF
--- a/appd.adoc
+++ b/appd.adoc
@@ -434,7 +434,7 @@ No `standard_name` has been defined for `z1`, `z2`, `a`, `href` or `k_c`.
 .Consistent sets of values for the standard_names of formula terms and the computed_standard_name needed in defining the ocean sigma coordinate, the ocean s-coordinate,  the ocean_sigma over z coordinate, and the ocean double sigma coordinate.
 image::NFFFFFF-1.0.png[caption=""]
 
-[options="header",cols="1,3,2,3",caption="Table D.1."]
+[options="header",cols="1,3,2,3",caption="Table D.1. "]
 |===============
 
 | option | standard_name of computed  dimensional coordinate | formula term name |

--- a/appi.adoc
+++ b/appi.adoc
@@ -42,7 +42,7 @@ The CF data model has been derived from these CF-netCDF elements and relationshi
 
 [[table-cf-concepts]]
 .The elements of the CF-netCDF conventions. The relationships to netCDF elements are shown in <<figure-cf-concepts>>.
-[options="header",cols="2",caption=""]
+[options="header",cols="2",caption="Table I.1. "]
 |===============
 |{set:cellbgcolor!}
 CF-netCDF element
@@ -104,7 +104,7 @@ The constructs, listed in <<table-cf-constructs, Table I.2>>, are related to CF-
 
 [[table-cf-constructs]]
 .The constructs of the CF data model. The relationships between the constructs and CF-netCDF elements are shown in in <<figure-field>>, <<figure-dim-aux>> and <<figure-coordinate-reference>>.
-[options="header",cols="2",caption=""]
+[options="header",cols="2",caption="Table I.2. "]
 |===============
 |{set:cellbgcolor!}
 CF construct
@@ -309,7 +309,7 @@ For example, in a coordinate conversion for converting between ocean sigma and h
 In the case of a named term being a type of coordinate variable, that variable will correspond to an independent domain ancillary construct in addition to the coordinate construct; that is, a single CF-netCDF variable is translated into two constructs (see <<cdl-domain-anc-coordinate, Example I.1>>).
 
 [[cdl-domain-anc-coordinate]]
-[caption=""]
+[caption="Example I.1. "]
 .A single CF-netCDF variable corresponding to two data model constructs.
 ====
 ----

--- a/ch02.adoc
+++ b/ch02.adoc
@@ -32,7 +32,7 @@ If the atomic string option is chosen, each element of the variable can be assig
 The CDL example below shows one variable of each type.
 
 [[char-and-string-variables-ex]]
-[caption="Example 1.1. "]
+[caption="Example 2.1. "]
 .String Variable Representations
 ====
 ----

--- a/ch03.adoc
+++ b/ch03.adoc
@@ -183,7 +183,7 @@ Several examples are listed below:
 The following example illustrates the use of three of these flags to represent two independent quality control tests and an aggregate flag that combines the results of the two tests.
 
 [[quality-flag-ex]]
-[caption="Example 3.3 "]
+[caption="Example 3.3. "]
 .Ancillary quality flag data
 ====
 

--- a/history.adoc
+++ b/history.adoc
@@ -13,7 +13,8 @@
 * {pull-requests}408[Pull request #408]: Deleted a sentence on "rotated Mercator" under `Oblique Mercator` grid mapping in Appendix F
 * {issues}260[Issue #260]: Clarify use of dimensionless units
 * {issues}410[Issue #410]: Delete "on a spherical Earth" from the definition of the `latitude_longitude` grid mapping in Appendix F 
-* {issues}286[Issue #286]: Some labels of examples contain "Example" so that their label in the list of examples contains "Example" (affects four examples)
+* {issues}286[Issue #286]: Some labels of examples contain "Example" so that their label in the list of examples contains "Example" (affects four examples); corrected captions of three tables and five examples
+* {issues}418[Issue #418]: Add missing examples to TOE (table of examples); corrected captions of three tables and three examples
 
 === Version 1.10 (31 August 2022)
 

--- a/toc-extra.adoc
+++ b/toc-extra.adoc
@@ -15,6 +15,7 @@ I.2. <<table-cf-constructs>>
 **List of Examples**
 
 [%hardbreaks]
+2.1. <<char-and-string-variables-ex>>
 3.1. <<use-of-standard-name-ex>>
 3.2. <<instrument-data-ex>>
 3.3. <<quality-flag-ex>>
@@ -38,7 +39,14 @@ I.2. <<table-cf-constructs>>
 5.10. <<british-national-grid>>
 5.11. <<latitude-and-longitude-on-the-wgs-1984-datum-in-crs-wkt-format>>
 5.12. <<british-national-grid-newlyn-datum-in-crs-wkt-format>>
-5.13. <<multiple-forecasts-from-single-analysis>>
+5.13. <<british-national-grid-newlyn-datum-with-wgs84-in-crs-wkt-format>>
+5.14. <<multiple-forecasts-from-single-analysis>>
+5.15. <<a-domain-with-independent-coordinate-variables>>
+5.16. <<a-domain-with-a-rotated-pole-grid-and-a-scalar-coordinate-variable>>
+5.17. <<a-domain-containing-cell-areas-for-a-spherical-geodesic-grid>>
+5.18. <<a-domain-with-no-explicit-dimensions>>
+5.19. <<a-domain-containing-a-timeseries-geometry>>
+5.20. <<a-domain-containing-a-timeseries-of-station-data-in-the-indexed-ragged-array-representation>>
 6.1. <<northward-heat-transport-in-atlantic-ocean-ex>>
 6.1.2. <<taxa-ex>>
 6.2. <<model-level-numbers-ex>>


### PR DESCRIPTION
* added several examples to the list of examples
* Example I.1 now has the caption "Example I.1"
* caption "Examples 1.1. " was changes to "Example 2.1. " (because it is in chapter/section 2 and not in chapter/section 1)
* changed "5.13." to "5.14." because a new examples 5.13 was inserted
* appended a space to caption `"Table D.1."` => `"Table D.1. "`
* added captions `Table I.1. ` and `Table I.1. `
* added a `.` to a caption in chapter 3
* updated history

See issue #418 for discussion of these changes. Replaces #419 .

# Release checklist
- [ ] Authors updated in `cf-conventions.adoc`? **(no reason to do so)**
- [ ] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org). **(no reason to do so)**
- [x] `history.adoc` up to date?
- [ ] Conformance document up-to-date? **(no reason to do so)**

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then `main` always is a draft for the next version.
