### PR TITLE
Minor fix on  text alignment

### DIFF
--- a/apph.adoc
+++ b/apph.adoc
@@ -778,8 +778,8 @@ In that case, any unused elements of the data and auxiliary coordinate variables
 
    variables:
       string trajectory(trajectory) ;
-        trajectory:cf_role = "trajectory_id";
-        trajectory:long_name = "trajectory name" ;
+          trajectory:cf_role = "trajectory_id";
+          trajectory:long_name = "trajectory name" ;
       int trajectory_info(trajectory) ;
           trajectory_info:long_name = "some kind of trajectory info"
 
@@ -801,7 +801,7 @@ In that case, any unused elements of the data and auxiliary coordinate variables
           z:long_name = "height above mean sea level" ;
           z:units = "km" ;
           z:positive = "up" ;
-           z:axis = "Z" ;
+          z:axis = "Z" ;
 
       float O3(trajectory, obs) ;
           O3:standard_name = “mass_fraction_of_ozone_in_air”;
@@ -862,7 +862,7 @@ This is a special case of the multidimensional array representation.
           z:long_name = "height above mean sea level" ;
           z:units = "km" ;
           z:positive = "up" ;
-           z:axis = "Z" ;
+          z:axis = "Z" ;
 
       float O3(time) ;
           O3:standard_name = “mass_fraction_of_ozone_in_air”;
@@ -926,7 +926,7 @@ The canonical use case for this is when rewriting raw data, and you expect that 
           z:long_name = "height above mean sea level" ;
           z:units = "km" ;
           z:positive = "up" ;
-           z:axis = "Z" ;
+          z:axis = "Z" ;
 
       float O3(obs) ;
           O3:standard_name = “mass_fraction_of_ozone_in_air”;
@@ -1076,7 +1076,7 @@ When storing time series of profiles at multiple stations in the same data varia
           alt:long_name = "height above mean sea level" ;
           alt:units = "km" ;
           alt:positive = "up" ;
-           alt:axis = "Z" ;  
+          alt:axis = "Z" ;  
 
       double time(station, profile ) ;
           time:standard_name = "time";
@@ -1277,7 +1277,7 @@ The canonical use case is when writing real-time data streams that contain profi
           z:long_name = "height above mean sea level" ;
           z:units = "km" ;
           z:axis = "Z" ;  
-           z:positive = "up" ;
+          z:positive = "up" ;
 
       float pressure(obs) ;
           pressure:standard_name = "air_pressure" ;
@@ -1433,7 +1433,7 @@ If there is only one trajectory in the data variable, there is no need for the t
           alt:long_name = "height above mean sea level" ;
           alt:units = "km" ;
           alt:positive = "up" ;
-           alt:axis = "Z" ;  
+          alt:axis = "Z" ;  
 
       double time(profile ) ;
           time:standard_name = "time";


### PR DESCRIPTION
Minor fix on text alignment. Doesn't change the meaning of the content. No associated issue for such a minor change.

# Release checklist
- [ ] Authors updated in `cf-conventions.adoc`?
- [ ] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [ ] `history.adoc` up to date?
- [ ] Conformance document up-to-date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then `master` always is a draft for the next version.
