### PR TITLE
Hardcoded creation date-time replaced by attribute "docprodtime"

### DIFF
--- a/cf-conventions.adoc
+++ b/cf-conventions.adoc
@@ -1,7 +1,7 @@
 include::version.adoc[]
 = NetCDF Climate and Forecast (CF) Metadata Conventions
 Brian{nbsp}Eaton; Jonathan{nbsp}Gregory; Bob{nbsp}Drach; Karl{nbsp}Taylor; Steve{nbsp}Hankin; Jon{nbsp}Blower; John{nbsp}Caron; Rich{nbsp}Signell; Phil{nbsp}Bentley; Greg{nbsp}Rappa; Heinke{nbsp}Höck; Alison{nbsp}Pamment; Martin{nbsp}Juckes; Martin{nbsp}Raspaud; Randy{nbsp}Horne; Timothy{nbsp}Whiteaker; David{nbsp}Blodgett; Charlie{nbsp}Zender; Daniel{nbsp}Lee; David{nbsp}Hassell; Alan{nbsp}D.{nbsp}Snow; Tobias{nbsp}Kölling; Dave{nbsp}Allured; Aleksandar{nbsp}Jelenak; Anders{nbsp}Meier{nbsp}Soerensen; Lucile{nbsp}Gaultier; Sylvain{nbsp}Herlédan; Fernando{nbsp}Manzano; Lars{nbsp}Bärring; Chris{nbsp}Barker
-Version {current-version}, 31 August, 2022
+Version{nbsp}{current-version},{nbsp}{nbsp}{docprodtime}
 :doctype: book
 :pdf-folio-placement: physical
 :sectanchors:

--- a/history.adoc
+++ b/history.adoc
@@ -7,6 +7,7 @@
 
 === Working version (most recent first)
 
+* {issues}457[Issue #457]: Creation date of the draft Conventions document 
 * {issues}458[Issue #458]: Fix broken link to Unidata documentation.
 * {issues}423[Issue #423]: Always use "strictly monotonic" when describing coordinate variables
 * {issues}420[Issue #420]: Add List of Figures


### PR DESCRIPTION
**N.B. Requires updates to the github workflow as *suggested* below.**

See issue #457 for discussion of the changes.

# Release checklist
- [ NA] Authors updated in `cf-conventions.adoc`?
- [ NA] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [yes] `history.adoc` up to date?
- [ NA] Conformance document up-to-date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then `master` always is a draft for the next version.

Replacing the hardcoded document creation date with an AsciiDoc attribute (with more flexible formatting than the builtin `{localdatetime}`) requires the format specification attribute to be set at the command line. The code changes below have not been tested in a github workflow, but the corresponding shell commands works when run locally.

```yaml
... 
...
 - name: Set draft date-time formatting       ## new
      if github.event_name != 'release'       ## new
      run: |       ## new
        echo "DATE_FMT='+%d&#160;%B,&#160;%Y&#160;%H:%M:%SZ'" >> "$GITHUB_ENV"       ## new
 - name: Set "final" tag and date-time formatting       ## changed
      if: github.event_name == 'release'
      run: |
        echo "FINAL_TAG=-a final" >> "$GITHUB_ENV"; echo "DATE_FMT='+%d&#160;%B,&#160;%Y'" >> "$GITHUB_ENV"       ## changed
    # Build cf-conventions.html using the Analog-inc asciidoctor-action
    - name: Build cf-conventions.html
      uses: Analog-inc/asciidoctor-action@v1.2
      with:
        shellcommand: 'asciidoctor --verbose ${FINAL_TAG} -a docprodtime="$(date -u ${DATE_FMT})" cf-conventions.adoc -D conventions_build; cp -r images conventions_build'      ## changed
    # Build cf-conventions.pdf using the Analog-inc asciidoctor-action
    - name: Build cf-conventions.pdf
      uses: Analog-inc/asciidoctor-action@v1.2
      with:
        shellcommand: 'asciidoctor-pdf --verbose ${FINAL_TAG} -a docprodtime="$(date -u ${DATE_FMT})" -d book cf-conventions.adoc -D conventions_build'       ## changed
    # Upload artifact containing cf-conventions.html, cf-conventions.pdf
```
Could possibly someone from the *Information Management and Support Team* have a look at this?
ping e.g. @DocOtak, @sadielbartholomew, @cofinoa, @davidhassell 
