### PR TITLE
deleted rogue spaces in table F.1 (left column)

### DIFF
--- a/appf.adoc
+++ b/appf.adoc
@@ -465,7 +465,7 @@ If **`false_northing`** is not provided it is assumed to be 0.
 The formula to convert from the coordinate value as written in the **`projection_y_coordinate`** (yf) to a value (y0) used in a transformation without **`false_northing`**, i.e.
 **`false_northing`**= 0, is: y0 = yf -**`false_northing`**
 
-| **`fixed_angle_axis `** | S
+| **`fixed_angle_axis`** | S
 | Indicates the axis on which the view is fixed in a hypothetical gimbal view model of the Earth, as used in the geostationary grid mapping.
 It corresponds to the inner-gimbal axis of the gimbal view model, whose axis of rotation moves about the outer-gimbal axis.
 This value can adopt two values, "x" or "y", corresponding with the Earth's E-W or N-S axis, respectively.
@@ -603,7 +603,7 @@ Domain: **`-90.0 &lt;= standard_parallel &lt;= 90.0`**
 | The longitude (degrees_east) to be oriented straight up from the North or South Pole.
 Domain: **`-180.0 &lt;= straight_vertical_longitude_from_pole &lt; 180.0`**
 
-| **`sweep_angle_axis `** | S
+| **`sweep_angle_axis`** | S
 | Indicates the axis on which the view sweeps in a hypothetical gimbal view model of the Earth, as used in the geostationary grid mapping.
 It corresponds to the outer-gimbal axis of the gimbal view model, about whose axis of rotation the gimbal-gimbal axis moves.
 This value can adopt two values, "x" or "y", corresponding with the Earth's E-W or N-S axis, respectively.


### PR DESCRIPTION
In Table F.1, left column, rogue spaces made the backticks not work properly for attributes `fixed_angle_axis` and `sweep_angel_axis`.  
