### PR TITLE
Add a missing author to the list

### DIFF
--- a/cf-conventions.adoc
+++ b/cf-conventions.adoc
@@ -1,6 +1,6 @@
 include::version.adoc[]
 = NetCDF Climate and Forecast (CF) Metadata Conventions
-Brian{nbsp}Eaton; Jonathan{nbsp}Gregory; Bob{nbsp}Drach; Karl{nbsp}Taylor; Steve{nbsp}Hankin; Jon{nbsp}Blower; John{nbsp}Caron; Rich{nbsp}Signell; Phil{nbsp}Bentley; Greg{nbsp}Rappa; Heinke{nbsp}Höck; Alison{nbsp}Pamment; Martin{nbsp}Juckes; Martin{nbsp}Raspaud; Randy{nbsp}Horne; Timothy{nbsp}Whiteaker; David{nbsp}Blodgett; Charlie{nbsp}Zender; Daniel{nbsp}Lee; David{nbsp}Hassell; Alan{nbsp}D.{nbsp}Snow; Tobias{nbsp}Kölling; Dave{nbsp}Allured; Aleksandar{nbsp}Jelenak; Anders{nbsp}Meier{nbsp}Soerensen; Lucile{nbsp}Gaultier; Sylvain{nbsp}Herlédan; Fernando{nbsp}Manzano; Lars{nbsp}Bärring; Chris{nbsp}Barker
+Brian{nbsp}Eaton; Jonathan{nbsp}Gregory; Bob{nbsp}Drach; Karl{nbsp}Taylor; Steve{nbsp}Hankin; Jon{nbsp}Blower; John{nbsp}Caron; Rich{nbsp}Signell; Phil{nbsp}Bentley; Greg{nbsp}Rappa; Heinke{nbsp}Höck; Alison{nbsp}Pamment; Martin{nbsp}Juckes; Martin{nbsp}Raspaud; Randy{nbsp}Horne; Timothy{nbsp}Whiteaker; David{nbsp}Blodgett; Charlie{nbsp}Zender; Daniel{nbsp}Lee; David{nbsp}Hassell; Alan{nbsp}D.{nbsp}Snow; Tobias{nbsp}Kölling; Dave{nbsp}Allured; Aleksandar{nbsp}Jelenak; Anders{nbsp}Meier{nbsp}Soerensen; Lucile{nbsp}Gaultier; Sylvain{nbsp}Herlédan; Fernando{nbsp}Manzano; Lars{nbsp}Bärring; Christopher{nbsp}Barker
 Version {current-version}, 31 August, 2022: See https://cfconventions.org for further information
 :doctype: book
 :pdf-folio-placement: physical
@@ -47,7 +47,7 @@ include::toc-extra.adoc[]
 * Sylvain Herlédan, OceanDataLab
 * Fernando Manzano, Puertos del Estado
 * Lars Bärring, SMHI
-* Chris Barker, NOAA
+* Christopher Barker, NOAA
 
 Many others have contributed to the development of CF through their participation in discussions about proposed changes.
 

--- a/cf-conventions.adoc
+++ b/cf-conventions.adoc
@@ -1,6 +1,6 @@
 include::version.adoc[]
 = NetCDF Climate and Forecast (CF) Metadata Conventions
-Brian{nbsp}Eaton; Jonathan{nbsp}Gregory; Bob{nbsp}Drach; Karl{nbsp}Taylor; Steve{nbsp}Hankin; Jon{nbsp}Blower; John{nbsp}Caron; Rich{nbsp}Signell; Phil{nbsp}Bentley; Greg{nbsp}Rappa; Heinke{nbsp}Höck; Alison{nbsp}Pamment; Martin{nbsp}Juckes; Martin{nbsp}Raspaud; Randy{nbsp}Horne; Timothy{nbsp}Whiteaker; David{nbsp}Blodgett; Charlie{nbsp}Zender; Daniel{nbsp}Lee; David{nbsp}Hassell; Alan{nbsp}D.{nbsp}Snow; Tobias{nbsp}Kölling; Dave{nbsp}Allured; Aleksandar{nbsp}Jelenak; Anders{nbsp}Meier{nbsp}Soerensen; Lucile{nbsp}Gaultier; Sylvain{nbsp}Herlédan; Fernando{nbsp}Manzano; Lars{nbsp}Bärring
+Brian{nbsp}Eaton; Jonathan{nbsp}Gregory; Bob{nbsp}Drach; Karl{nbsp}Taylor; Steve{nbsp}Hankin; Jon{nbsp}Blower; John{nbsp}Caron; Rich{nbsp}Signell; Phil{nbsp}Bentley; Greg{nbsp}Rappa; Heinke{nbsp}Höck; Alison{nbsp}Pamment; Martin{nbsp}Juckes; Martin{nbsp}Raspaud; Randy{nbsp}Horne; Timothy{nbsp}Whiteaker; David{nbsp}Blodgett; Charlie{nbsp}Zender; Daniel{nbsp}Lee; David{nbsp}Hassell; Alan{nbsp}D.{nbsp}Snow; Tobias{nbsp}Kölling; Dave{nbsp}Allured; Aleksandar{nbsp}Jelenak; Anders{nbsp}Meier{nbsp}Soerensen; Lucile{nbsp}Gaultier; Sylvain{nbsp}Herlédan; Fernando{nbsp}Manzano; Lars{nbsp}Bärring; Chris{nbsp}Barker
 Version {current-version}, 31 August, 2022: See https://cfconventions.org for further information
 :doctype: book
 :pdf-folio-placement: physical

--- a/history.adoc
+++ b/history.adoc
@@ -7,6 +7,7 @@
 
 === Working version (most recent first)
 
+* {issues}483[Issue #483]: Add a missing author
 * {issues}463[Issue #463]: Convert URLs with HTTP protocol to HTTPS if available, fixed a few dead links
 * {issues}383[Issue #383]: Link to the CF website and deleted the Preface section
 * {issues}472[Issue #472]: Fix incorrect formating for some \<= symbols


### PR DESCRIPTION
See issue #483 for discussion of these changes.

# Release checklist
- [NA] Authors updated in `cf-conventions.adoc`?
- [NA] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [Y] `history.adoc` up to date?
- [NA] Conformance document up-to-date?
