### PR TITLE
Technical updates to front page "version line"

### DIFF
--- a/.github/workflows/adoc_build.yml
+++ b/.github/workflows/adoc_build.yml
@@ -57,7 +57,7 @@ jobs:
       with:
         shellcommand: 'asciidoctor --verbose ${FINAL_TAG} -a docprodtime=$(date -u ${DATE_FMT}) cf-conventions.adoc -D conventions_build; cp -r images conventions_build'
     # Patch the cfconventions.org link
-    - run: sed -i 's+https://cfconventions.org+<a href="https://cfconventions.org" target="_blank">https://cfconventions.org</a>+' ./conventions_build/cf-conventions.html
+    - run: sed -E -i 's+(https://cfconventions.org)+<a href="\1" target="_blank">\1</a>+' ./conventions_build/cf-conventions.html
     # Build cf-conventions.pdf using the Analog-inc asciidoctor-action
     - name: Build cf-conventions.pdf
       uses: Analog-inc/asciidoctor-action@v1.2

--- a/.github/workflows/adoc_build.yml
+++ b/.github/workflows/adoc_build.yml
@@ -33,7 +33,6 @@ on:
   release:
     types:
       - published
-
 jobs:
   # Job to build cf-conventions.html, cf-conventions.pdf
   build_conventions:
@@ -57,6 +56,8 @@ jobs:
       uses: Analog-inc/asciidoctor-action@v1.2
       with:
         shellcommand: 'asciidoctor --verbose ${FINAL_TAG} -a docprodtime=$(date -u ${DATE_FMT}) cf-conventions.adoc -D conventions_build; cp -r images conventions_build'
+    # Patch the cfconventions.org link
+    - run: sed -i 's+See https://cfconventions.org+<a href="https://cfconventions.org" target="_blank">https://cfconventions.org</a>+' ./conventions_build/cf-conventions.html
     # Build cf-conventions.pdf using the Analog-inc asciidoctor-action
     - name: Build cf-conventions.pdf
       uses: Analog-inc/asciidoctor-action@v1.2

--- a/.github/workflows/adoc_build.yml
+++ b/.github/workflows/adoc_build.yml
@@ -57,7 +57,7 @@ jobs:
       with:
         shellcommand: 'asciidoctor --verbose ${FINAL_TAG} -a docprodtime=$(date -u ${DATE_FMT}) cf-conventions.adoc -D conventions_build; cp -r images conventions_build'
     # Patch the cfconventions.org link
-    - run: sed -i 's+See https://cfconventions.org+<a href="https://cfconventions.org" target="_blank">https://cfconventions.org</a>+' ./conventions_build/cf-conventions.html
+    - run: sed -i 's+https://cfconventions.org+<a href="https://cfconventions.org" target="_blank">https://cfconventions.org</a>+' ./conventions_build/cf-conventions.html
     # Build cf-conventions.pdf using the Analog-inc asciidoctor-action
     - name: Build cf-conventions.pdf
       uses: Analog-inc/asciidoctor-action@v1.2

--- a/cf-conventions.adoc
+++ b/cf-conventions.adoc
@@ -1,8 +1,7 @@
 include::version.adoc[]
 = NetCDF Climate and Forecast (CF) Metadata Conventions
 Brian{nbsp}Eaton; Jonathan{nbsp}Gregory; Bob{nbsp}Drach; Karl{nbsp}Taylor; Steve{nbsp}Hankin; Jon{nbsp}Blower; John{nbsp}Caron; Rich{nbsp}Signell; Phil{nbsp}Bentley; Greg{nbsp}Rappa; Heinke{nbsp}Höck; Alison{nbsp}Pamment; Martin{nbsp}Juckes; Martin{nbsp}Raspaud; Randy{nbsp}Horne; Timothy{nbsp}Whiteaker; David{nbsp}Blodgett; Charlie{nbsp}Zender; Daniel{nbsp}Lee; David{nbsp}Hassell; Alan{nbsp}D.{nbsp}Snow; Tobias{nbsp}Kölling; Dave{nbsp}Allured; Aleksandar{nbsp}Jelenak; Anders{nbsp}Meier{nbsp}Soerensen; Lucile{nbsp}Gaultier; Sylvain{nbsp}Herlédan; Fernando{nbsp}Manzano; Lars{nbsp}Bärring; Christopher{nbsp}Barker; Sadie{nbsp}Bartholomew
-Version{nbsp}{current-version},{nbsp}{nbsp}{docprodtime}: See{nbsp}https://cfconventions.org{nbsp}for{nbsp}further{nbsp}information
->>>>>>> 3a4ea6d (changed some spaces to non-breaking spaces in the version line)
+Version{nbsp}{current-version},{nbsp}{nbsp}{docprodtime}: See{nbsp}<https://cfconventions.org>{nbsp}for{nbsp}further{nbsp}information.
 :doctype: book
 :pdf-folio-placement: physical
 :sectanchors:

--- a/cf-conventions.adoc
+++ b/cf-conventions.adoc
@@ -1,7 +1,7 @@
 include::version.adoc[]
 = NetCDF Climate and Forecast (CF) Metadata Conventions
 Brian{nbsp}Eaton; Jonathan{nbsp}Gregory; Bob{nbsp}Drach; Karl{nbsp}Taylor; Steve{nbsp}Hankin; Jon{nbsp}Blower; John{nbsp}Caron; Rich{nbsp}Signell; Phil{nbsp}Bentley; Greg{nbsp}Rappa; Heinke{nbsp}Höck; Alison{nbsp}Pamment; Martin{nbsp}Juckes; Martin{nbsp}Raspaud; Randy{nbsp}Horne; Timothy{nbsp}Whiteaker; David{nbsp}Blodgett; Charlie{nbsp}Zender; Daniel{nbsp}Lee; David{nbsp}Hassell; Alan{nbsp}D.{nbsp}Snow; Tobias{nbsp}Kölling; Dave{nbsp}Allured; Aleksandar{nbsp}Jelenak; Anders{nbsp}Meier{nbsp}Soerensen; Lucile{nbsp}Gaultier; Sylvain{nbsp}Herlédan; Fernando{nbsp}Manzano; Lars{nbsp}Bärring; Christopher{nbsp}Barker; Sadie{nbsp}Bartholomew
-Version{nbsp}{current-version},{nbsp}{nbsp}{docprodtime}: See{nbsp}<https://cfconventions.org>{nbsp}for{nbsp}further{nbsp}information.
+Version{nbsp}{current-version},{nbsp}{nbsp}{docprodtime}: See{nbsp}https://cfconventions.org{nbsp}for{nbsp}further{nbsp}information.
 :doctype: book
 :pdf-folio-placement: physical
 :sectanchors:

--- a/cf-conventions.adoc
+++ b/cf-conventions.adoc
@@ -1,7 +1,8 @@
 include::version.adoc[]
 = NetCDF Climate and Forecast (CF) Metadata Conventions
 Brian{nbsp}Eaton; Jonathan{nbsp}Gregory; Bob{nbsp}Drach; Karl{nbsp}Taylor; Steve{nbsp}Hankin; Jon{nbsp}Blower; John{nbsp}Caron; Rich{nbsp}Signell; Phil{nbsp}Bentley; Greg{nbsp}Rappa; Heinke{nbsp}Höck; Alison{nbsp}Pamment; Martin{nbsp}Juckes; Martin{nbsp}Raspaud; Randy{nbsp}Horne; Timothy{nbsp}Whiteaker; David{nbsp}Blodgett; Charlie{nbsp}Zender; Daniel{nbsp}Lee; David{nbsp}Hassell; Alan{nbsp}D.{nbsp}Snow; Tobias{nbsp}Kölling; Dave{nbsp}Allured; Aleksandar{nbsp}Jelenak; Anders{nbsp}Meier{nbsp}Soerensen; Lucile{nbsp}Gaultier; Sylvain{nbsp}Herlédan; Fernando{nbsp}Manzano; Lars{nbsp}Bärring; Christopher{nbsp}Barker; Sadie{nbsp}Bartholomew
-Version{nbsp}{current-version},{nbsp}{nbsp}{docprodtime}: See https://cfconventions.org for further information
+Version{nbsp}{current-version},{nbsp}{nbsp}{docprodtime}: See{nbsp}https://cfconventions.org{nbsp}for{nbsp}further{nbsp}information
+>>>>>>> 3a4ea6d (changed some spaces to non-breaking spaces in the version line)
 :doctype: book
 :pdf-folio-placement: physical
 :sectanchors:


### PR DESCRIPTION
~~See issue #XXX for discussion of these changes.~~
This PR, which has no associated issue,  is intended to do two things: 
* Activate the html link to https://cfconventions.org in the "version line" (below author list) of the html document. 
* Change the spaces in the text related to the same html link to non-breaking spaces so that a possible line break in the pdf version does not chop up the text (this should have been done already in PR#464.  

# Release checklist
- [x] Authors updated in `cf-conventions.adoc`?
- [x] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [x] `history.adoc` up to date?
- [x] Conformance document up-to-date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then, `main` always is a draft for the next version.
