### PR TITLE
Minor update to PR template community file

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ See issue #XXX for discussion of these changes.
 - [ ] Authors updated in `cf-conventions.adoc`? Add in two places: on line 3 and under `.Additional Authors` in `About the authors`.
 - [ ] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
 - [ ] `history.adoc` up to date?
-- [ ] Conformance document up-to-date?
+- [ ] Conformance document up to date?
 
 # For maintainers
 After the merge remember to delete the source branch.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 See issue #XXX for discussion of these changes.
 
 # Release checklist
-- [ ] Authors updated in `cf-conventions.adoc`?
+- [ ] Authors updated in `cf-conventions.adoc`? Add in two places: on line 3 and under `.Additional Authors` in `About the authors`.
 - [ ] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
 - [ ] `history.adoc` up to date?
 - [ ] Conformance document up-to-date?


### PR DESCRIPTION
~~See issue #XXX for discussion of these changes.~~
See https://github.com/cf-convention/cf-conventions/pull/489#issuecomment-1827828116 for the context behind the core update, which is to state to be explicit that there are two places where names should be updated in the `cf-conventions.adoc` document, preventing confusion in future that led to separate PRs being required to add names again.

Since this is an infrastructure tweak, the release checklist is not applicable so I have quoted it to effectively comment it out.

@larsbarring I have assigned you as reviewer since you are quite active on this repo of late, but feel free to re-assign should you wish. I don't think the change is controversial but will need someone to approve it regardless to confirm it's OK. Thanks.

> # Release checklist
> - [  ] Authors updated in `cf-conventions.adoc`?
> - [ ] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
> - [ ] `history.adoc` up to date?
> - [ ] Conformance document up-to-date?
> - [ ] 

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then, `main` always is a draft for the next version.
