### PR TITLE
Fix malformed external links

### DIFF
--- a/.github/workflows/adoc_build.yml
+++ b/.github/workflows/adoc_build.yml
@@ -57,7 +57,7 @@ jobs:
       with:
         shellcommand: 'asciidoctor --verbose ${FINAL_TAG} -a docprodtime=$(date -u ${DATE_FMT}) cf-conventions.adoc -D conventions_build; cp -r images conventions_build'
     # Patch the cfconventions.org link
-    - run: sed -E -i 's+(https://cfconventions.org)+<a href="\1" target="_blank">\1</a>+' ./conventions_build/cf-conventions.html
+    - run: sed -E -i 's+(See&#160;)(https://cfconventions.org)(&#160;for&#160;further&#160;information.)+\1<a href="\2" target="_blank">\2</a>\3+' ./conventions_build/cf-conventions.html
     # Build cf-conventions.pdf using the Analog-inc asciidoctor-action
     - name: Build cf-conventions.pdf
       uses: Analog-inc/asciidoctor-action@v1.2

--- a/ch02.adoc
+++ b/ch02.adoc
@@ -16,7 +16,7 @@ NetCDF files should have the file name extension "**`.nc`**".
 === Data Types
 
 // TODO: Check, should this be a bullet list?
-Data variables must be one of the following data types: **`string`**, **`char`**, **`byte`**, **`unsigned byte`**, **`short`**, **`unsigned short`**, **`int`**, **`unsigned int`**, **`int64`**, **`unsigned int64`**, **`float`** or **`real`**, and **`double`** (which are all the [netCDF external data types](https://docs.unidata.ucar.edu/nug/current/md_types.html) supported by netCDF-4).
+Data variables must be one of the following data types: **`string`**, **`char`**, **`byte`**, **`unsigned byte`**, **`short`**, **`unsigned short`**, **`int`**, **`unsigned int`**, **`int64`**, **`unsigned int64`**, **`float`** or **`real`**, and **`double`** (which are all the link:$$https://docs.unidata.ucar.edu/nug/current/md_types.html$$[netCDF external data types] supported by netCDF-4).
 The **`string`** type is only available in files using the netCDF version 4 (netCDF-4) format.
 The **`char`** and **`string`** types are not intended for numeric data.
 One byte numeric data should be stored using the **`byte`** or **`unsigned byte`** data types.
@@ -56,7 +56,7 @@ The examples in this document that use string-valued variables alternate between
 Variable, dimension, attribute and group names should begin with a letter and be composed of letters, digits, and underscores.
 By the word _letters_ we mean the standard ASCII letters uppercase `A` to `Z` and lowercase `a` to `z`.
 By the word _digits_ we mean the standard ASCII digits `0` to `9`, and similarly _underscores_ means the standard ASCII underscore `_`.
-Note that this is in conformance with the COARDS conventions, but is more restrictive than the netCDF interface which allows almost all Unicode characters encoded as multibyte UTF-8 characters ([NUG Appendix B](https://docs.unidata.ucar.edu/nug/current/file_format_specifications.html).
+Note that this is in conformance with the COARDS conventions, but is more restrictive than the netCDF interface which allows almost all Unicode characters encoded as multibyte UTF-8 characters (link:$$https://docs.unidata.ucar.edu/nug/current/file_format_specifications.html$$[NUG Appendix B]).
 The netCDF interface also allows leading underscores in names, but the NUG states that this is reserved for system use.
 
 Case is significant in netCDF names, but it is recommended that names should not be distinguished purely by case, i.e., if case is disregarded, no two names should be the same.

--- a/ch03.adoc
+++ b/ch03.adoc
@@ -98,11 +98,11 @@ The description may define rules on the variable type, attributes and coordinate
 When appropriate, the table entry also contains the corresponding GRIB parameter code(s) (from ECMWF and NCEP) and AMIP identifiers.
 
 The standard name table is located at
-https://cfconventions.org/Data/cf-standard-names/current/src/cf-standard-name-table.xml,
+link:$$https://cfconventions.org/Data/cf-standard-names/current/src/cf-standard-name-table.xml$$[https://cfconventions.org/Data/cf-standard-names/current/src/cf-standard-name-table.xml],
 written in compliance with the XML format, as described in <<standard-name-table-format>>.
 Knowledge of the XML format is only necessary for application writers who plan to directly access the table.
 A formatted text version of the table is provided at
-https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html,
+link:$$https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html$$[https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html],
 and this table may be consulted in order to find the standard name that should be assigned to a variable.
 Some standard names (e.g. **`region`** and **`area_type`**) are used to indicate quantities which are permitted to take only certain standard values.
 This is indicated in the definition of the quantity in the standard name table, accompanied by a list or a link to a list of the permitted values.


### PR DESCRIPTION
~~See issue #XXX for discussion of these changes.~~
Formatting improvement: a few malformed external links have been updated to render correctly. Suggest no history entry is needed.

# Release checklist
- [x] Authors updated in `cf-conventions.adoc`? Add in two places: on line 3 and under `.Additional Authors` in `About the authors`.
- [x] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [ ] `history.adoc` up to date?
- [x] Conformance document up to date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then, `main` always is a draft for the next version.
