### PR TITLE
Update to `actions/...@v3`

### DIFF
--- a/.github/workflows/adoc_build.yml
+++ b/.github/workflows/adoc_build.yml
@@ -65,7 +65,7 @@ jobs:
         shellcommand: 'asciidoctor-pdf --verbose ${FINAL_TAG} -a docprodtime=$(date -u ${DATE_FMT}) -d book -a pdf-theme=default-theme-CF-version.yml --trace cf-conventions.adoc -D conventions_build'
     # Upload artifact containing cf-conventions.html, cf-conventions.pdf
     - name: Upload cf-conventions doc preview
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: conventions_docs
         path: conventions_build/
@@ -94,7 +94,7 @@ jobs:
         shellcommand: 'asciidoctor-pdf --verbose ${FINAL_TAG} -d book conformance.adoc -D conformance_build'
     # Upload artifact containing conformance.html, conformance.pdf
     - name: Upload conformance doc preview
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: conformance_docs
         path: conformance_build/
@@ -110,7 +110,7 @@ jobs:
     - uses: actions/checkout@v3
     # Create the image_directory artifact
     - name: Upload images directory
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: image_directory
         path: images/
@@ -145,7 +145,7 @@ jobs:
           fi
       # Obtain the build artifacts from the previous jobs and place them in the
       # build/ directory
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           path: build/
       # If we are doing a release, we need to create the release directory

--- a/.github/workflows/adoc_build.yml
+++ b/.github/workflows/adoc_build.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # Check out PR
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # Create build directory
     - run: mkdir conventions_build
     - name: Set draft date-time formatting
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # Checkout PR
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # Create build directory
     - run: mkdir conformance_build
     - name: Set "final" tag
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # Checkout ref
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # Create the image_directory artifact
     - name: Upload images directory
       uses: actions/upload-artifact@v2
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout gh-pages branch
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: 'gh-pages'
       # Will new docs go into root, or into a directory named after the


### PR DESCRIPTION
~See issue #XXX for discussion of these changes.~
Update GitHub actions to use  `actions/checkout@v3`, `actions/upload-artifact@v3`, and `actions/download-artifact@v3 (from `v2`) to remove the following type of report from the actions:
```
The following actions uses node12 which is deprecated and will be forced to
run on node16: actions/checkout@v2, actions/upload-artifact@v2.
For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

# Release checklist
- [x] Authors updated in `cf-conventions.adoc`? Add in two places: on line 3 and under `.Additional Authors` in `About the authors`.
- [x] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [x] `history.adoc` up to date?
- [x] Conformance document up to date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then, `main` always is a draft for the next version.
