### PR TITLE
corrections to units_metadata text

### DIFF
--- a/appa.adoc
+++ b/appa.adoc
@@ -347,7 +347,13 @@ In cases where there is a strong constraint on dataset size, it is allowed to pa
 | S
 | C, D, BI
 | link:$$https://www.unidata.ucar.edu/software/netcdf/docs/attribute_conventions.html$$[NUG Appendix A, "Attribute Conventions"], and <<units>>
-| Units of a variable"s content.
+| Units of a variable's content.
+
+| **`units_metadata`**
+| S
+| C, D, BI
+| <<units>>
+| Specifies the interpretation (on-scale, difference or unknown) of the unit of temperature appearing in the **`units`** attribute.
 
 | **`valid_max`**
 | N

--- a/ch03.adoc
+++ b/ch03.adoc
@@ -25,7 +25,7 @@ Special treatment is required in converting the **`units`** of variables that in
 
 The COARDS convention prohibits the unit `degrees` altogether, but this unit is not forbidden by the CF convention because it may in fact be appropriate for a variable containing, say, solar zenith angle.
 The unit `degrees` is also allowed on coordinate variables such as the latitude and longitude coordinates of a transformed grid.
-In this case the coordinate values are not true latitudes and longitudes which must always be identified using the more specific forms of `degrees` as described in <<latitude-coordinate>> and <<longitude-coordinate>>.
+In this case the coordinate values are not true latitudes and longitudes, which must always be identified using the more specific forms of `degrees` as described in <<latitude-coordinate>> and <<longitude-coordinate>>.
 
 
 [[dimensionless-units, Section 3.1.1, "Dimensionless units"]]
@@ -103,7 +103,7 @@ This value of **`units_metadata`** indicates that the data-writer does not know 
 If the **`units_metadata`** attribute is not present, the data-reader should assume `temperature: unknown`.
 The **`units_metadata`** attribute was introduced in CF 1.11.
 In data written according to versions before 1.11, `temperature: unknown` should be assumed for all **`units`** involving temperature, if it cannot be deduced from other metadata.
-We note (for guidance only for `temperature: unknown`, not as a CF convention) that the UDUNITS software assumes `temperature: on_scale` for **`units`** strings containing only a unit of temperature, and `temperature: difference` for **`units`** strings in which a unit of temperature is raised to any power other than unity, or multiplied or divided by any other unit.
+We note (for guidance _only_ regarding `temperature: unknown`, _not_ as a CF convention) that the UDUNITS software assumes `temperature: on_scale` for **`units`** strings containing only a unit of temperature, and `temperature: difference` for **`units`** strings in which a unit of temperature is raised to any power other than unity, or multiplied or divided by any other unit.
 
 With `temperature: on_scale`, correct conversion can be guaranteed only for pure temperature **`units`**.
 If the quantity is an on-scale temperature multiplied by some other quantity, it is not possible to convert the data from the **`units`** given to any other **`units`** that involve a temperature with a different origin, given only the **`units`**.
@@ -116,7 +116,7 @@ For instance, when temperature is on-scale, a value in `kg degree_C m-2` can be 
 UDUNITS recognises the SI prefixes shown in <<table-supported-units>> for decimal multiples and submultiples of units, and allows them to be applied to non-SI units as well.
 UDUNITS offers a syntax for indicating arbitrary scale factors and offsets to be applied to a unit.
 (Note that this is different from the scale factors and offsets used for converting between **`units`**, as discussed for temperature in <<temperature-units>>.)
-This UDUNITS syntax for arbitrary transformation of **`units`** is not supported by **the CF** standard, except for the case of specifying reference time (<<time-coordinate>>).
+This UDUNITS syntax for arbitrary transformation of **`units`** is not supported by the CF standard, except for the case of specifying reference time (<<time-coordinate>>).
 The application of any scale factors or offsets to data should be indicated by the **`scale_factor`** and **`add_offset`** attributes.
 Use of these attributes for data packing, which is their most important application, is discussed in detail in <<packed-data>>.
 


### PR DESCRIPTION
See issue #496 for discussion of these changes.

# Release checklist
- [x] Authors updated in `cf-conventions.adoc`? Add in two places: on line 3 and under `.Additional Authors` in `About the authors`.
- [x] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [x] `history.adoc` up to date?
- [x] Conformance document up to date?