### PR TITLE
Update revision history headings for CF-1.11

### DIFF
--- a/history.adoc
+++ b/history.adoc
@@ -5,7 +5,7 @@
 [[revhistory, Revision History]]
 == Revision History
 
-=== Working version (most recent first)
+=== Version 1.11 (05 December 2023)
 
 * {issues}481[Issue #481]: Introduce **`units_metadata`** attribute and clarify some other aspects of **`units`**
 * {issues}458[Issue #147]: Clarify the use of compressed dimensions in related variables


### PR DESCRIPTION
~See issue #XXX for discussion of these changes.~

# Release checklist
- [x] Authors updated in `cf-conventions.adoc`? Add in two places: on line 3 and under `.Additional Authors` in `About the authors`.
- [x] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [x] `history.adoc` up to date?
- [x] Conformance document up to date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then, `main` always is a draft for the next version.
