### PR TITLE
Appendix B: In exceptional cases allow a standard name to be aliased into two alternatives

### DIFF
--- a/appb.adoc
+++ b/appb.adoc
@@ -84,6 +84,16 @@ Each **`alias`** element contains a single element:
   </alias>
 ----
 
+In exceptional cases the **`alias`** element may contain two elements:
+
+----
+  <alias id="an_id">
+    <entry_id>Identifier of a defining entry ... </entry_id>
+    <entry_id>Identifier of another defining entry ... </entry_id>
+  </alias>
+----
+
+
 [[name-table-three-entries-ex]]
 [caption="Example B.1. "]
 .A name table containing three entries

--- a/history.adoc
+++ b/history.adoc
@@ -7,6 +7,7 @@
 
 === Working version (most recent first)
 
+* {issues}509[Issue #509]: In exceptional cases allow a standard name to be aliased into two alternatives
 * {issues}477[Issue #477]: Period and hyphen allowed in attribute names
 * {issues}500[Issue #500]: Appendix B: Added a **`conventions`** string to the standard name xml file format definition
 


### PR DESCRIPTION
See issue #509 for discussion of these changes.

# Release checklist
- `N/A` Authors updated in `cf-conventions.adoc`? Add in two places: on line 3 and under `.Additional Authors` in `About the authors`.
- `N/A` Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [x] `history.adoc` up to date?
- `N/A` Conformance document up to date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then, `main` always is a draft for the next version.
