### PR TITLE
Appendix B: New element in XML file header to record the "first published date"

### DIFF
--- a/appb.adoc
+++ b/appb.adoc
@@ -26,7 +26,8 @@ The content (delimited by the `&lt;standard_name_table&gt;` tags) consists of, i
 
 ----
   <version_number>Version number here ... </version_number>
-  <conventions>Conventions string here ... </conventions> 
+  <conventions>Conventions string here ... </conventions>
+  <first_published>Datetime of first publication to the website ... </first_published>
   <last_modified>Datetime stamp here ... </last_modified>
   <institution>Name of institution here ... </institution>
   <contact>E-mail address of contact person ... </contact>

--- a/history.adoc
+++ b/history.adoc
@@ -7,6 +7,7 @@
 
 === Working version (most recent first)
 
+* {issues}511[Issue #511]: Appendix B: New element in XML file header to record the "first published date"
 * {issues}509[Issue #509]: In exceptional cases allow a standard name to be aliased into two alternatives
 * {issues}501[Issue #501]: Clarify that data variables and variables containing coordinate data are highly recommended to have **`long_name`** or **`standard_name`** attributes, that **`cf_role`** is used only for discrete sampling geometries and UGRID mesh topologies, and that CF does not prohibit CF attributes from being used in ways that are not defined by CF but that in such cases their meaning is not defined by CF.
 * {issues}477[Issue #477]: Period and hyphen allowed in attribute names


### PR DESCRIPTION
See issue #511 for discussion of these changes.

# Release checklist
[N/A]  Authors updated in `cf-conventions.adoc`? Add in two places: on line 3 and under `.Additional Authors` in `About the authors`.

[N/A] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [X] `history.adoc` up to date?

[N/A] Conformance document up to date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then, `main` always is a draft for the next version.
