### PR TITLE
Fix trac links

### DIFF
--- a/appf.adoc
+++ b/appf.adoc
@@ -57,7 +57,7 @@ __Map coordinates:__:: The x (abscissa) and y (ordinate) rectangular coordinates
 __Notes:__:: Notes on using the **`PROJ`** software package for computing the mapping may be found at
 link:$$http://geotiff.maptools.org/proj_list/azimuthal_equidistant.html$$[http://geotiff.maptools.org/proj_list/azimuthal_equidistant.html]
 and
-link:$$http://proj.org/operations/projections/aeqd.html$$[https://proj.org/operations/projections/aeqd.html].
+link:$$https://proj.org/operations/projections/aeqd.html$$[https://proj.org/operations/projections/aeqd.html].
 
 === Geostationary projection
 

--- a/history.adoc
+++ b/history.adoc
@@ -1,6 +1,6 @@
 :issues: https://github.com/cf-convention/cf-conventions/issues/
 :pull-requests: https://github.com/cf-convention/cf-conventions/pull/
-:tickets: https://cfconventions.org/Data/trac.html
+:tickets: https://cfconventions.org/Data/Trac-tickets/
 
 [[revhistory, Revision History]]
 == Revision History


### PR DESCRIPTION
This is a link fixing 

# Release checklist
- [NA] Authors updated in `cf-conventions.adoc`? Add in two places: on line 3 and under `.Additional Authors` in `About the authors`.
- [NA] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [] `history.adoc` up to date?
- [NA] Conformance document up to date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then, `main` always is a draft for the next version.
