### PR TITLE
Clarify that the character set given in section 2.3 for variable, dimension, attribute and group names is a recommendation, not a requirement

### DIFF
--- a/ch02.adoc
+++ b/ch02.adoc
@@ -46,7 +46,7 @@ The examples in this document that use string-valued variables alternate between
 
 === Naming Conventions
 
-Variable, dimension, attribute and group names should begin with a letter and be composed of letters, digits, and underscores.
+It is recommended that variable, dimension, attribute and group names begin with a letter and be composed of letters, digits, and underscores.
 By the word _letters_ we mean the standard ASCII letters uppercase `A` to `Z` and lowercase `a` to `z`.
 By the word _digits_ we mean the standard ASCII digits `0` to `9`, and similarly _underscores_ means the standard ASCII underscore `_`.
 Note that this is in conformance with the COARDS conventions, but is more restrictive than the netCDF interface which allows almost all Unicode characters encoded as multibyte UTF-8 characters (link:$$https://docs.unidata.ucar.edu/nug/current/file_format_specifications.html$$[NUG Appendix B]).

--- a/history.adoc
+++ b/history.adoc
@@ -7,6 +7,7 @@
 
 === Working version (most recent first)
 
+* {issues}237[Issue #237]: Clarify that the character set given in section 2.3 for variable, dimension, attribute and group names is a recommendation, not a requirement.
 * {issues}515[Issue #515]: Clarify the recommendation to use the convention of 4.3.3 for parametric vertical coordinates, because the previous wording caused confusion.
 * {issues}511[Issue #511]: Appendix B: New element in XML file header to record the "first published date"
 * {issues}509[Issue #509]: In exceptional cases allow a standard name to be aliased into two alternatives


### PR DESCRIPTION
See issue #237 for discussion of these changes.

# Release checklist
- [NA] Authors updated in `cf-conventions.adoc`? Add in two places: on line 3 and under `.Additional Authors` in `About the authors`.
- [NA] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [Y] `history.adoc` up to date?
- [NA] Conformance document up to date?