### PR TITLE
Fix typo 'principal' -> 'principle' in ch02

### DIFF
--- a/ch02.adoc
+++ b/ch02.adoc
@@ -199,7 +199,7 @@ References to out-of-group variable and dimensions shall be found by applying th
 
 ==== Scope
 
-The scoping mechanism is in keeping with the following principal:
+The scoping mechanism is in keeping with the following principle:
 
 [quote, 'https://www.unidata.ucar.edu/software/netcdf/docs/groups.html[The NetCDF Data Model: Groups]']
 "Dimensions are scoped such that they are visible to all child groups.


### PR DESCRIPTION
(I haven't opened an issue for discussion of these changes because it is a small typo)

Not sure what needs doing with the checklist below as this is a very minor typo!

# Release checklist
- [ ] Authors updated in `cf-conventions.adoc`? Add in two places: on line 3 and under `.Additional Authors` in `About the authors`.
- [ ] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [ ] `history.adoc` up to date?
- [ ] Conformance document up to date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then, `main` always is a draft for the next version.
