### PR TITLE
 A one-dimensional string-valued variable must not have the same name as its dimension

### DIFF
--- a/ch01.adoc
+++ b/ch01.adoc
@@ -74,10 +74,12 @@ All examples in this document use CDL syntax.
 cell:: A region in one or more dimensions whose boundary can be described by a set of vertices.
 The term __interval__ is sometimes used for one-dimensional cells.
 
-coordinate variable:: We use this term precisely as it is defined in the
-link:$$https://docs.unidata.ucar.edu/nug/current/best_practices.html#bp_Coordinate-Systems$$[NUG section on coordinate variables].
-It is a one-dimensional variable with the same name as its dimension [e.g., **`time(time)`**], and it is defined as a numeric data type with values in strict monotonic order (all values are different, and they are arranged in either consistently increasing or consistently decreasing order).
+coordinate variable:: A coordinate variable is a one-dimensional variable with the same name as its dimension e.g., **`time(time)`**.
+In CF, a coordinate variable must be of a numeric data type (note that
+link:$$https://docs.unidata.ucar.edu/nug/current/best_practices.html#bp_Coordinate-Systems$$[NUG section on coordinate variables] does not have this requirement).
+The coordinate values must be in strict monotonic order (all values are different, and they are arranged in either consistently increasing or consistently decreasing order).
 Missing values are not allowed in coordinate variables.
+To avoid confusion with coordinate variables, CF does not permit a one-dimensional string-valued variable to have the same name as its dimension.
 
 grid mapping variable:: A variable used as a container for attributes that define a specific grid mapping.
 The type of the variable is arbitrary since it contains no data.

--- a/conformance.adoc
+++ b/conformance.adoc
@@ -56,6 +56,12 @@ See https://github.com/ugrid-conventions/ugrid-conventions for the UGRID conform
 
 [[section-3]]
 
+=== 2.5 Variables
+
+*Requirements:*
+
+* A one-dimensional string-valued variable must not have the same name as its dimension (see "Coordinate variable" in Section 1.3).
+
 [[missing-data-valid-and-actual-range-of-data]]
 === 2.5.1 Missing data, valid and actual range of data
 

--- a/history.adoc
+++ b/history.adoc
@@ -7,6 +7,7 @@
 
 === Working version (most recent first)
 
+* {issues}174[Issue #174]: A one-dimensional string-valued variable must not have the same name as its dimension, in order to avoid its being mistaken for a coordinate variable.
 * {issues}237[Issue #237]: Clarify that the character set given in section 2.3 for variable, dimension, attribute and group names is a recommendation, not a requirement.
 * {issues}515[Issue #515]: Clarify the recommendation to use the convention of 4.3.3 for parametric vertical coordinates, because the previous wording caused confusion.
 * {issues}511[Issue #511]: Appendix B: New element in XML file header to record the "first published date"


### PR DESCRIPTION
See issue #174 for discussion of these changes.

# Release checklist
- [NA] Authors updated in `cf-conventions.adoc`? Add in two places: on line 3 and under `.Additional Authors` in `About the authors`.
- [NA] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [Y] `history.adoc` up to date?
- [Y] Conformance document up to date?