### PR TITLE
Clarification of position of comment in `cell_methods`

### DIFF
--- a/ch07.adoc
+++ b/ch07.adoc
@@ -328,7 +328,7 @@ The horizontal coordinate variables to which "**`area`**" refers are in this cas
 [[recording-spacing-original-data]]
 ==== Recording the spacing of the original data and other information
 
-To indicate more precisely how the cell method was applied, extra information may be included in parentheses () after the identification of the method.
+To indicate more precisely how the cell method was applied, extra information may be included in parentheses () at the end of the word list describing the method, after the operation and any **`where`**, **`over`** and **`within`** phrases.
 This information includes standardized and non-standardized parts.
 Currently the only standardized information is to provide the typical interval between the original data values to which the method was applied, in the situation where the present data values are statistically representative of original data values which had a finer spacing.
 The syntax is (**`interval`**: __value unit__), where __value__ is a numerical value and __unit__ is a string that can be recognized by UNIDATA's UDUNITS package <<UDUNITS>>.

--- a/ch07.adoc
+++ b/ch07.adoc
@@ -328,7 +328,7 @@ The horizontal coordinate variables to which "**`area`**" refers are in this cas
 [[recording-spacing-original-data]]
 ==== Recording the spacing of the original data and other information
 
-To indicate more precisely how the cell method was applied, extra information may be included in parentheses () at the end of the word list describing the method, after the operation and any **`where`**, **`over`** and **`within`** phrases.
+To indicate more precisely how the cell method was applied, extra information may be included in parentheses **`( )`** at the end of the word list describing the method, after the operation and any **`where`**, **`over`** and **`within`** phrases.
 This information includes standardized and non-standardized parts.
 Currently the only standardized information is to provide the typical interval between the original data values to which the method was applied, in the situation where the present data values are statistically representative of original data values which had a finer spacing.
 The syntax is (**`interval`**: __value unit__), where __value__ is a numerical value and __unit__ is a string that can be recognized by UNIDATA's UDUNITS package <<UDUNITS>>.


### PR DESCRIPTION
See issue #274 for discussion of these changes.

# Release checklist
- [NA] Authors updated in `cf-conventions.adoc`? Add in two places: on line 3 and under `.Additional Authors` in `About the authors`.
- [NA] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [NA] `history.adoc` up to date? - No need to update, because this simply corrects a defect.
- [NA] Conformance document up to date?