### PR TITLE
correct mistakes in history

### DIFF
--- a/history.adoc
+++ b/history.adoc
@@ -8,7 +8,7 @@
 === Working version (most recent first)
 
 * {issues}403[Issue #403]: Metadata to encode quantization properties
-* {issues}530{Issue #530]: Define "the most rapidly varying dimension", and use this phrase consistently with the clarification "(the last dimension in CDL order)".
+* {issues}530[Issue #530]: Define "the most rapidly varying dimension", and use this phrase consistently with the clarification "(the last dimension in CDL order)".
 * {issues}163[Issue #163]: Provide a convention for boundary variables for grids whose cells do not all have the same number of sides.
 * {issues}174[Issue #174]: A one-dimensional string-valued variable must not have the same name as its dimension, in order to avoid its being mistaken for a coordinate variable.
 * {issues}237[Issue #237]: Clarify that the character set given in section 2.3 for variable, dimension, attribute and group names is a recommendation, not a requirement.
@@ -22,7 +22,7 @@
 === Version 1.11 (05 December 2023)
 
 * {issues}481[Issue #481]: Introduce **`units_metadata`** attribute and clarify some other aspects of **`units`**
-* {issues}458[Issue #147]: Clarify the use of compressed dimensions in related variables
+* {issues}458[Issue #458]: Clarify the use of compressed dimensions in related variables
 * {issues}486[Issue #486]: Fix PDF formatting problems and invalid references
 * {issues}490[Issue #490]: Simple correction to Example 6.1.2
 * {issues}457[Issue #457]: Creation date of the draft Conventions document 


### PR DESCRIPTION
See issue #545 for discussion of these changes.

# Release checklist
- [NA] Authors updated in `cf-conventions.adoc`? Add in two places: on line 3 and under `.Additional Authors` in `About the authors`.
- [NA] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [Y] `history.adoc` up to date?
- [NA] Conformance document up to date?