### PR TITLE
ch02: Revert PR 478, period and hyphen in names

### DIFF
--- a/ch02.adoc
+++ b/ch02.adoc
@@ -51,7 +51,6 @@ By the word _letters_ we mean the standard ASCII letters uppercase `A` to `Z` an
 By the word _digits_ we mean the standard ASCII digits `0` to `9`, and similarly _underscores_ means the standard ASCII underscore `_`.
 Note that this is in conformance with the COARDS conventions, but is more restrictive than the netCDF interface which allows almost all Unicode characters encoded as multibyte UTF-8 characters (link:$$https://docs.unidata.ucar.edu/nug/current/file_format_specifications.html$$[NUG Appendix B]).
 The netCDF interface also allows leading underscores in names, but the NUG states that this is reserved for system use.
-ASCII period (.) and ASCII hyphen (-) are also allowed in attribute names only.
 
 Case is significant in netCDF names, but it is recommended that names should not be distinguished purely by case, i.e., if case is disregarded, no two names should be the same.
 It is also recommended that names should be obviously meaningful, if possible, as this renders the file more effectively self-describing.

--- a/conformance.adoc
+++ b/conformance.adoc
@@ -37,7 +37,6 @@ See https://github.com/ugrid-conventions/ugrid-conventions for the UGRID conform
 *Recommendations:*
 
 * Variable, dimension and attribute names should begin with a letter and be composed of letters (A-Z, a-z), digits (0-9), and underscores(_). This corresponds to ASCII characters in the decimal ranges (65-90), (97-122), (48-57), and (95). The corresponding Unicode codepoints are (U+0041-U+005A), (U+0061-U+007A), (U+0030-U+0039), and (U+005F).  
-* ASCII period (.) and ASCII hyphen (-) may also be included in attribute names only.
 * No two variable names should be identical when case is ignored.
 
 [[section-2]]

--- a/history.adoc
+++ b/history.adoc
@@ -16,7 +16,6 @@
 * {issues}511[Issue #511]: Appendix B: New element in XML file header to record the "first published date"
 * {issues}509[Issue #509]: In exceptional cases allow a standard name to be aliased into two alternatives
 * {issues}501[Issue #501]: Clarify that data variables and variables containing coordinate data are highly recommended to have **`long_name`** or **`standard_name`** attributes, that **`cf_role`** is used only for discrete sampling geometries and UGRID mesh topologies, and that CF does not prohibit CF attributes from being used in ways that are not defined by CF but that in such cases their meaning is not defined by CF.
-* {issues}477[Issue #477]: Period and hyphen allowed in attribute names
 * {issues}500[Issue #500]: Appendix B: Added a **`conventions`** string to the standard name xml file format definition
 
 === Version 1.11 (05 December 2023)


### PR DESCRIPTION
* Revert PR #478.
* Remove this single line from [section 2.3, Naming Conventions](http://cfconventions.org/cf-conventions/cf-conventions.html#_naming_conventions):
"ASCII period (.) and ASCII hyphen (-) are also allowed in attribute names only."
* See issue #548 for discussion of these changes.

# Release checklist
- [NA] Authors updated in `cf-conventions.adoc`? Add in two places: on line 3 and under `.Additional Authors` in `About the authors`.
- [NA] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [x] `history.adoc` up to date?
- [x] Conformance document up to date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then, `main` always is a draft for the next version.