### PR TITLE
Remove GRIB and AMIP information from the format of the standard name table

### DIFF
--- a/appb.adoc
+++ b/appb.adoc
@@ -62,18 +62,6 @@ Each **`entry`** element contains the following elements:
   </entry>
 ----
 
-`Entry` elements may optionally also contain the following elements:
-
-----
-  <grib>GRIB parameter code</grib>
-  <amip>AMIP identifier string</amip>
-----
-
-Not all variables have equivalent AMIP or GRIB codes.
-ECMWF GRIB codes start with **`E`**, NCEP codes with **`N`**.
-Standard codes (in the range 1-127) are not prefaced.
-When a variable has more than one equivalent GRIB code, the alternatives are given as a blank-separated list.
-
 The **`alias`** elements do not contain definitions.
 Rather they contain the value of the **`id`** attribute of an **`entry`** element that contains the sought after definition.
 The purpose of the **`alias`** elements are to provide a means for maintaining the table in a backwards compatible fashion.
@@ -114,16 +102,12 @@ In exceptional cases the **`alias`** element may contain two elements:
     <contact>support@pcmdi.llnl.gov</contact>
     <entry id="surface_air_pressure">
       <canonical_units>Pa</canonical_units>
-      <grib>E134</grib>
-      <amip>ps</amip>
       <description>
           The surface called "surface" means the lower boundary of the atmosphere.
       </description>
     </entry>
     <entry id="air_pressure_at_sea_level">
       <canonical_units>Pa</canonical_units>
-      <grib>2 E151</grib>
-      <amip>psl</amip>
       <description>
           Air pressure at sea level is the quantity often abbreviated
           as MSLP or PMSL. sea_level means mean sea level, which is close

--- a/history.adoc
+++ b/history.adoc
@@ -7,6 +7,7 @@
 
 === Working version (most recent first)
 
+* {issues}367{Issue #367}: Remove the AMIP and GRIB columns from the standard name table format defined by Appendix B.
 * {issues}403[Issue #403]: Metadata to encode quantization properties
 * {issues}530[Issue #530]: Define "the most rapidly varying dimension", and use this phrase consistently with the clarification "(the last dimension in CDL order)".
 * {issues}163[Issue #163]: Provide a convention for boundary variables for grids whose cells do not all have the same number of sides.


### PR DESCRIPTION
See issue #367 for discussion of these changes.

# Release checklist
- [NA] Authors updated in `cf-conventions.adoc`? Add in two places: on line 3 and under `.Additional Authors` in `About the authors`.
- [Y] `history.adoc` up to date?
- [NA] Conformance document up to date?
