### PR TITLE
WIP: updating time examples to use doubles / ints.

### DIFF
--- a/ch05.adoc
+++ b/ch05.adoc
@@ -69,9 +69,9 @@ variables:
   float pres(pres) ;
     pres:long_name = "pressure" ;
     pres:units = "hPa" ;
-  double time(time) ;
+  int64 time(time) ;
     time:long_name = "time" ;
-    time:units = "days since 1990-1-1 0:0:0" ;
+    time:units = "seconds since 1990-1-1 0:0:0" ;
 ----
 
 ====
@@ -665,12 +665,12 @@ dimensions:
   lon = 360 ;
   time = UNLIMITED ;
 variables:
-  double atime
+  int atime
     atime:standard_name = "forecast_reference_time" ;
-    atime:units = "hours since 1999-01-01 00:00" ;
-  double time(time);
+    atime:units = "seconds since 1999-01-01 00:00" ;
+  int time(time);
     time:standard_name = "time" ;
-    time:units = "hours since 1999-01-01 00:00" ;
+    time:units = "seconds since 1999-01-01 00:00" ;
   double lon(lon) ;
     lon:long_name = "station longitude";
     lon:units = "degrees_east";
@@ -1022,9 +1022,9 @@ variables:
     mesh_edge_nodes:long_name = "Maps each edge to the 2 nodes it connects" ;
 
   // Coordinate variables
-  double time(time) ;
+  int64 time(time) ;
     time:standard_name = "time" ;
-    time:units = "days since 2004-06-01" ;
+    time:units = "seconds since 2004-06-01" ;
 
   // Data at mesh faces
   double volume_at_faces(time, face) ;

--- a/ch05.adoc
+++ b/ch05.adoc
@@ -831,7 +831,7 @@ variables:
     lat:long_name = "latitude" ;
     lat:units = "degrees_north" ;
     lat:bounds = "lat_vertices" ;
-  float time(time) ;
+  double time(time) ;
     time:long_name = "time" ;
     time:units = "days since 1979-01-01" ;
   float cell_area(cell) ;
@@ -1022,7 +1022,7 @@ variables:
     mesh_edge_nodes:long_name = "Maps each edge to the 2 nodes it connects" ;
 
   // Coordinate variables
-  float time(time) ;
+  double time(time) ;
     time:standard_name = "time" ;
     time:units = "days since 2004-06-01" ;
 

--- a/ch06.adoc
+++ b/ch06.adoc
@@ -92,7 +92,7 @@ dimension:
   string80 = 80 ;
   taxon = 2 ;
 variables:
-  float time(time);
+  double time(time);
     time:standard_name = "time" ;
     time:units = "days since 2019-01-01" ;
   float abundance(time,taxon) ;

--- a/ch07.adoc
+++ b/ch07.adoc
@@ -224,7 +224,7 @@ variables:
     lat:long_name = "latitude" ;
     lat:units = "degrees_north" ;
     lat:bounds="lat_vertices" ;
-  float time(time) ;
+  double time(time) ;
     time:long_name = "time" ;
     time:units = "days since 1979-01-01 0:0:0" ;
   float cell_area(cell) ;
@@ -299,7 +299,7 @@ variables:
   double time_bnds(time,nv);
 data:
   time = 0., 12., 24., 36., 48.;
-  time_bnds = -12.,0., 0.,12., 12.,24., 24.,36., 36.,48.;
+  time_bnds = -12., 0., 0., 12., 12., 24., 24., 36., 36., 48.;
 ----
 Note that in this example the time axis values coincide with the end of each interval.
 It is sometimes desirable, however, to use the midpoint of intervals as coordinate values for variables that are representative of an interval.
@@ -363,10 +363,10 @@ variables:
     TS_var:long_name="surface air temperature variance"
     TS_var:units="K2";
     TS_var:cell_methods="time: variance (interval: 1 hr comment: sampled instantaneously)";
-  float time(time);
+  double time(time);
     time:units="days since 1990-01-01 00:00:00";
     time:bounds="time_bnds";
-  float time_bnds(time,nv);
+  double time_bnds(time,nv);
 data:
   time=.5;
   time_bnds=0.,1.;

--- a/ch07.adoc
+++ b/ch07.adoc
@@ -292,7 +292,7 @@ variables:
     ppn:long_name = "depth of water-equivalent precipitation";
     ppn:units = "mm";
     ppn:cell_methods = "time: sum";
-  double time(time);
+  int time(time);
     time:long_name = "time";
     time:units = "h since 1998-4-19 6:0:0";
     time:bounds = "time_bnds";
@@ -363,8 +363,8 @@ variables:
     TS_var:long_name="surface air temperature variance"
     TS_var:units="K2";
     TS_var:cell_methods="time: variance (interval: 1 hr comment: sampled instantaneously)";
-  double time(time);
-    time:units="days since 1990-01-01 00:00:00";
+  int time(time);
+    time:units="hours since 1990-01-01 00:00:00";
     time:bounds="time_bnds";
   double time_bnds(time,nv);
 data:
@@ -535,7 +535,7 @@ variables:
     temperature:long_name="surface air temperature";
     temperature:cell_methods="time: minimum within years time: mean over years";
     temperature:units="K";
-  double time(time);
+  int time(time);
     time:climatology="climatology_bounds";
     time:units="days since 1960-1-1";
   double climatology_bounds(time,nv);
@@ -561,7 +561,7 @@ variables:
     precipitation:long_name="precipitation amount";
     precipitation:cell_methods="time: sum within years time: mean over years";
     precipitation:units="kg m-2";
-  double time(time);
+  int time(time);
     time:climatology="climatology_bounds";
     time:units="days since 1901-1-1";
   double climatology_bounds(time,nv);
@@ -587,7 +587,7 @@ variables:
     temperature:long_name="surface air temperature";
     temperature:cell_methods="time: mean within days time: mean over days";
     temperature:units="K";
-  double time(time);
+  int time(time);
     time:climatology="climatology_bounds";
     time:units="hours since 1997-4-1";
   double climatology_bounds(time,nv);
@@ -621,9 +621,9 @@ variables:
   float threshold;
     threshold:standard_name="air_temperature";
     threshold:units="degC";
-  double time;
+  int time;
     time:climatology="climatology_bounds";
-    time:units="days since 2000-6-1";
+    time:units="hours since 2000-6-1";
   double climatology_bounds(time,nv);
 data: // time coordinates translated to date/time format
   time="2008-1-16 6:00";
@@ -645,9 +645,9 @@ variables:
     temperature:cell_methods="time: mean within days ",
       "time: mean over days time: mean over years";
     temperature:units="K";
-  double time(time);
+  int64 time(time);
     time:climatology="climatology_bounds";
-    time:units="days since 1961-1-1";
+    time:units="minutes since 1961-1-1";
   double climatology_bounds(time,nv);
 data:  // time coordinates translated to date/time format
   time="1961-4-1 0:30", "1961-4-1 1:30", ..., "1961-4-1 23:30" ;
@@ -674,9 +674,9 @@ variables:
     precipitation:long_name="Accumulated precipitation";
     precipitation:cell_methods="time: sum within days time: maximum over days";
     precipitation:units="kg";
-  double time(time);
+  int time(time);
     time:climatology="climatology_bounds";
-    time:units="days since 2000-6-1";
+    time:units="hours since 2000-6-1";
   double climatology_bounds(time,nv);
 data:  // time coordinates translated to date/time format
   time="2000-6-16", "2000-7-16", "2000-8-16" ;

--- a/ch08.adoc
+++ b/ch08.adoc
@@ -489,9 +489,9 @@ variables:
     linear_y:computational_precision = "64" ;
 
   // tie point coordinate variables
-  double time(time) ;
+  int time(time) ;
     time:standard_name = "time" ;
-    time:units = "days since 2021-03-01" ;
+    time:units = "seconds since 2021-03-01" ;
   double y(time, tp_y) ;
     y:units = "km" ;
     y:standard_name = "projection_y_coordinate" ;


### PR DESCRIPTION
See Discussion: https://github.com/orgs/cf-convention/discussions/383

I think the consensus on that discussion was to:

[x] Change the `float` time examples to `double`
and
[x] Change some of the `double` examples to an  integer type.

I've done the first one -- more to follow.

# Release checklist
- [x] Authors updated in `cf-conventions.adoc`? Add in two places: on line 3 and under `.Additional Authors` in `About the authors`.
- [ ] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [ ] `history.adoc` up to date?
- [x] Conformance document up to date? (no impact)

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then, `main` always is a draft for the next version.
