### PR TITLE
Editorial changes for the CF-1.12 release documents

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,10 +1,10 @@
 {
   "metadata": {
     "title": "NetCDF Climate and Forecast (CF) Metadata Conventions",
-    "description": "This document describes the CF conventions for climate and forecast metadata designed to promote the processing and sharing of files created with the netCDF Application Programmer Interface. The conventions define metadata that provide a definitive description of what the data in each variable represents, and of the spatial and temporal properties of the data. This enables users of data from different sources to decide which quantities are comparable, and facilitates building applications with powerful extraction, regridding, and display capabilities. The CF conventions generalize and extend the COARDS conventions. The extensions include metadata that provides a precise definition of each variable via specification of a standard name, describes the vertical locations corresponding to dimensionless vertical coordinate values, and provides the spatial coordinates of non-rectilinear gridded data. Since climate and forecast data are often not simply representative of points in space/time, other extensions provide for the description of coordinate intervals, multidimensional cells and climatological time coordinates, and indicate how a data value is representative of an interval or cell. This standard also relaxes the COARDS constraints on dimension order and specifies methods for reducing the size of datasets.",
+    "description": "<p>This document describes the CF conventions for climate and forecast metadata designed to promote the processing and sharing of files created with the netCDF Application Programmer Interface. The conventions define metadata that provide a definitive description of what the data in each variable represents, and of the spatial and temporal properties of the data. This enables users of data from different sources to decide which quantities are comparable, and facilitates building applications with powerful extraction, regridding, and display capabilities.</p><p>The CF conventions generalize and extend the COARDS conventions. The extensions include metadata that provides a precise definition of each variable via specification of a standard name, describes the vertical locations corresponding to dimensionless vertical coordinate values, and provides the spatial coordinates of non-rectilinear gridded data. Since climate and forecast data are often not simply representative of points in space/time, other extensions provide for the description of coordinate intervals, multidimensional cells and climatological time coordinates, and indicate how a data value is representative of an interval or cell. This standard also relaxes the COARDS constraints on dimension order and specifies methods for reducing the size of datasets.</p>",
     "license": "CC0-1.0",
     "imprint_publisher": "CF Community",
-    "communities": [{"identifier": "cfconventions-sandbox"}],
+    "communities": [{"identifier": "cfconventions"}],
     "upload_type": "publication",
     "publication_type": "standard",
     "version": "1.12",
@@ -15,7 +15,6 @@
       { "name": "Drach, Bob", "affiliation": "PCMDI, LLNL" },
       { "name": "Taylor, Karl", "affiliation": "PCMDI, LLNL", "orcid": "0000-0002-6491-2135" },
       { "name": "Hankin, Steve", "affiliation": "PMEL, NOAA" },
-      { "name": "Blower, Jon", "affiliation": "University of Reading" },
       { "name": "Caron, John", "affiliation": "Unidata" },
       { "name": "Signell, Rich", "affiliation": "USGS" },
       { "name": "Bentley, Phil", "affiliation": "UK Met Office" },
@@ -24,10 +23,11 @@
       { "name": "Pamment, Alison", "affiliation": "NCAS and CEDA", "orcid": "0000-0001-5040-4626"},
       { "name": "Juckes, Martin", "affiliation": "NCAS" },
       { "name": "Raspaud, Martin", "affiliation": "SMHI" },
+      { "name": "Blower, Jon", "affiliation": "University of Reading" },
       { "name": "Horne, Randy", "affiliation": "Excalibur Laboratories Inc" },
       { "name": "Whiteaker, Timothy", "affiliation": "University of Texas" },
       { "name": "Blodgett, David", "affiliation": "USGS" },
-      { "name": "Zender, Charlie", "affiliation": "UC Irvine" },
+      { "name": "Zender, Charlie", "affiliation": "University of California, Irvine" },
       { "name": "Lee, Daniel", "affiliation": "EUMETSAT", "orcid": "0000-0002-1041-232X" },
       { "name": "Hassell, David", "affiliation": "NCAS and University of Reading", "orcid": "0000-0001-5106-7502" },
       { "name": "Snow, Alan D.", "affiliation": "Corteva Agriscience" },
@@ -38,22 +38,22 @@
       { "name": "Gaultier, Lucile", "affiliation": "OceanDataLab" },
       { "name": "Herlédan, Sylvain", "affiliation": "OceanDataLab" },
       { "name": "Manzano, Fernando", "affiliation": "Puertos del Estado, Madrid" },
-      { "name": "Bärring, Lars", "affiliation": "SMHI", "orcid": "0000-0001-7280-2502" },
+      { "name": "Bärring, Lars", "affiliation": "SMHI Rossby Centre, Swedish Meteorological and Hydrological Institute", "orcid": "0000-0001-7280-2502" },
       { "name": "Barker, Christopher", "affiliation": "NOAA" },
       { "name": "Bartholomew, Sadie L.", "affiliation": "National Centre for Atmospheric Science and University of Reading", "orcid": "0000-0002-6180-3603" }
     ], 
     "related_identifiers": [
       {
-        "relation": "isDerivedFrom",
-        "resource_type": "publication-standard",
-        "scheme": "url",
-        "identifier": "https://github.com/cf-convention/cf-conventions/tree/v1.12"
-      },
-      {
         "relation": "isDocumentedBy",
         "resource_type": "publication-standard",
         "scheme": "url",
         "identifier": "https://cfconventions.org/"
+      },
+      {
+        "relation": "isDerivedFrom",
+        "resource_type": "publication-standard",
+        "scheme": "url",
+        "identifier": "https://github.com/cf-convention/cf-conventions/tree/v1.12"
       },
       {
         "relation": "isIdenticalTo",
@@ -66,11 +66,18 @@
         "resource_type": "publication-standard",
         "scheme": "url",
         "identifier": "https://cfconventions.org/Data/cf-conventions/cf-conventions-v1.12/cf-conventions.pdf"
+      },
+      {
+        "relation": "isIdenticalTo",
+        "resource_type": "publication-standard",
+        "scheme": "url",
+        "identifier": "https://cfconventions.org/Data/cf-documents/requirements-recommendations/conformance-1.12.html"
       }
+
     ]
   },
   "files": [
-    {"filename": "cf-conventions.pdf", "size":  5979284, "checksum": "md5:24f73fade28dea807df0a6f5131b0384"},
-    {"filename":    "conformance.pdf", "size":   347588, "checksum": "md5:85ec577392275291de07eb78aadddfae"}
-  ]
+    {"filename": "cf-conventions.pdf", "size": 6136097, "checksum": "md5:3537b2c8bb82aa950d3ef8c0395b3795"},
+    {"filename":    "conformance.pdf", "size":  362748, "checksum": "md5:4fdaa837b0286da621f1a095cc4aef69"}
+    ]
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -77,7 +77,7 @@
     ]
   },
   "files": [
-    {"filename": "cf-conventions.pdf", "size": 6136097, "checksum": "md5:3537b2c8bb82aa950d3ef8c0395b3795"},
-    {"filename":    "conformance.pdf", "size":  362748, "checksum": "md5:4fdaa837b0286da621f1a095cc4aef69"}
+    {"filename": "cf-conventions.pdf", "size": 6135749, "checksum": "md5:2763f464f2ac9e5c44c02c5343a3b384"},
+    {"filename":    "conformance.pdf", "size":  362748, "checksum": "md5:97af0bb9601bf67deaf4f7aaad5c75d8"}
     ]
 }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ license:
 title: NetCDF Climate and Forecast (CF) Metadata Conventions
 version: '1.12'
 date-released: '2024-12-04'
-doi: 10.5072/zenodo.FFFFFF
+doi: 10.5281/zenodo.14275599
 abstract: This document describes the CF conventions for climate and forecast metadata
   designed to promote the processing and sharing of files created with the netCDF
   Application Programmer Interface. The conventions define metadata that provide a

--- a/appi.adoc
+++ b/appi.adoc
@@ -98,7 +98,7 @@ CF-netCDF element
 [caption="Figure {doc-part}.{counter:figure}. ", reftext=Figure {doc-part}.{figure}]
 [.text-center]
 .The relationships between CF-netCDF elements and their corresponding netCDF variables, dimensions and attributes (identified here with the "NC" prefix). It is useful to define an abstract generic coordinate variable that can be used to refer to coordinates when the their type (coordinate, auxiliary or scalar coordinate variable) is not an issue.
-image::images/cfdm_cf_concepts.svg[,60%,pdfwidth=50vw,align="center"]
+image::images/cfdm_cf_concepts.svg[,95%,pdfwidth=75vw,align="center"]
 
 [[data-model-the-cf-data-model]]
 === The CF data model
@@ -159,7 +159,7 @@ All CF-netCDF elements are mapped to field constructs, domain constructs or thei
 [caption="Figure {doc-part}.{counter:figure}. ", reftext=Figure {doc-part}.{figure}]
 [.text-center]
 .The constructs of the CF data model. The field and domain constructs correspond to CF-netCDF data and domain variables respectively (defined in <<figure-cf-concepts>> and identified here with the "CN" prefix). Relationships between the other constructs and CF-netCDF are given in <<figure-dim-aux>> and <<figure-coordinate-reference>>. It is useful to define an abstract generic coordinate construct that can be used to refer to coordinates when the their type (dimension or auxiliary coordinate construct) is not an issue.
-image::images/cfdm_field.svg[,40%,pdfwidth=50vw,align="center"]
+image::images/cfdm_field.svg[,60%,pdfwidth=50vw,align="center"]
 
 [[data-model-field-construct]]
 ==== Field construct

--- a/appj.adoc
+++ b/appj.adoc
@@ -87,7 +87,7 @@ In the two-dimensional case, `a = tp(tpi2, tpi1)`, `b = tp(tpi2, tpi1+1)`, `c = 
 [[common-conversions-and-formulas, Section J.2, "Common Conversions and Formulas"]]
 ==== Common Conversions and Formulas
 
-<<subsampling-formulas, Table J.1>> describes conversions and formulas that are used in the descriptions of the interpolation techniques.
+<<table-subsampling-formulas, Table J.1>> describes conversions and formulas that are used in the descriptions of the interpolation techniques.
 
 [[table-subsampling-formulas]]
 .Conversions and formulas used in the definitions of subsampling interpolation methods

--- a/cf-conventions.adoc
+++ b/cf-conventions.adoc
@@ -10,7 +10,7 @@ Brian{nbsp}Eaton; Jonathan{nbsp}Gregory; Bob{nbsp}Drach; Karl{nbsp}Taylor; Steve
 :toclevels: 3
 
 <<<
-Climate and Forecast Conventions version {current-version-as-attribute} DOI: link:https://doi.org/10.5281/zenodo.14275599[10.5281/zenodo.14275599]
+Climate and Forecast Conventions version {current-version-as-attribute} {doi-text}
 
 image:images/cc-zero.svg[,9%,pdfwidth=50vw]
 This document is dedicated to the public domain following the link:https://creativecommons.org/publicdomain/zero/1.0/[Creative Commons Zero v1.0 Universal] Deed.
@@ -20,13 +20,13 @@ ifdef::final[]
  +
  +
  _Use the following reference to cite this version of the document:_ +
-Eaton, B., Gregory, J., Drach, B., Taylor, K., Hankin, S. et al. (2024). NetCDF Climate and Forecast (CF) Metadata Conventions ({current-version-as-attribute}). CF Community. https://doi.org/10.5281/zenodo.14275599
+Eaton, B., Gregory, J., Drach, B., Taylor, K., Hankin, S. et al. (2024). NetCDF Climate and Forecast (CF) Metadata Conventions ({current-version-as-attribute}). CF Community. {doi-link}
 endif::[]
 ifndef::final[]
  +
  +
  _DON’T use the following reference to cite this version of the document, as it is only shown as a draft:_ +
-Eaton, B., Gregory, J., Drach, B., Taylor, K., Hankin, S. et al. (2024). NetCDF Climate and Forecast (CF) Metadata Conventions ({current-version-as-attribute}). CF Community. https://doi.org/10.5281/zenodo.XXXXXX
+Eaton, B., Gregory, J., Drach, B., Taylor, K., Hankin, S. et al. (2024). NetCDF Climate and Forecast (CF) Metadata Conventions ({current-version-as-attribute}). CF Community. {doi-link}
 endif::[]
 
 '''

--- a/cf-conventions.adoc
+++ b/cf-conventions.adoc
@@ -12,7 +12,7 @@ Brian{nbsp}Eaton; Jonathan{nbsp}Gregory; Bob{nbsp}Drach; Karl{nbsp}Taylor; Steve
 <<<
 Climate and Forecast Conventions version {current-version-as-attribute} {doi-text}
 
-image:images/cc-zero.svg[, 10%]
+image:images/cc-zero.svg[,9%,pdfwidth=50vw]
 This document is dedicated to the public domain following the link:https://creativecommons.org/publicdomain/zero/1.0/[Creative Commons Zero v1.0 Universal] Deed.
 
 The Climate and Forecasting Conventions website https://cfconventions.org/ contains additional resources and provides further information.

--- a/cf-conventions.adoc
+++ b/cf-conventions.adoc
@@ -26,7 +26,7 @@ ifndef::final[]
  +
  +
  _DON’T use the following reference to cite this version of the document, as it is only shown as a draft:_ +
-Eaton, B., Gregory, J., Drach, B., Taylor, K., Hankin, S. et al. (2024). NetCDF Climate and Forecast (CF) Metadata Conventions ({current-version-as-attribute}). CF Community. https://doi.org/10.5072/zenodo.XXXXXX
+Eaton, B., Gregory, J., Drach, B., Taylor, K., Hankin, S. et al. (2024). NetCDF Climate and Forecast (CF) Metadata Conventions ({current-version-as-attribute}). CF Community. https://doi.org/10.5281/zenodo.XXXXXX
 endif::[]
 
 '''

--- a/cf-conventions.adoc
+++ b/cf-conventions.adoc
@@ -10,7 +10,7 @@ Brian{nbsp}Eaton; Jonathan{nbsp}Gregory; Bob{nbsp}Drach; Karl{nbsp}Taylor; Steve
 :toclevels: 3
 
 <<<
-Climate and Forecast Conventions version {current-version-as-attribute} {doi-text}
+Climate and Forecast Conventions version {current-version-as-attribute} DOI: link:https://doi.org/10.5281/zenodo.14275599[10.5281/zenodo.14275599]
 
 image:images/cc-zero.svg[,9%,pdfwidth=50vw]
 This document is dedicated to the public domain following the link:https://creativecommons.org/publicdomain/zero/1.0/[Creative Commons Zero v1.0 Universal] Deed.
@@ -20,7 +20,7 @@ ifdef::final[]
  +
  +
  _Use the following reference to cite this version of the document:_ +
-Eaton, B., Gregory, J., Drach, B., Taylor, K., Hankin, S. et al. (2024). NetCDF Climate and Forecast (CF) Metadata Conventions ({current-version-as-attribute}). CF Community. https://doi.org/10.5072/zenodo.FFFFFF
+Eaton, B., Gregory, J., Drach, B., Taylor, K., Hankin, S. et al. (2024). NetCDF Climate and Forecast (CF) Metadata Conventions ({current-version-as-attribute}). CF Community. https://doi.org/10.5281/zenodo.14275599
 endif::[]
 ifndef::final[]
  +

--- a/ch03.adoc
+++ b/ch03.adoc
@@ -164,7 +164,8 @@ A standard name contains no whitespace and is case sensitive.
 
 canonical units:: Representative units of the physical quantity.
 Unless it is dimensionless, a variable with a **`standard_name`** attribute must have units which are physically equivalent (not necessarily identical) to the canonical units, possibly modified by an operation specified by the standard name modifier (see below and <<standard-name-modifiers>>) or by the **`cell_methods`** attribute (see <<cell-methods>> and <<appendix-cell-methods>>) or both.
-
+ +
+ +
 Units of time coordinates (<<time-coordinate>>), whose **`units`** attribute includes the word **`since`**, are _not_ physically equivalent to time units that do not include **`since`** in the **`units`**.
 To mark this distinction, the canonical unit given for quantities used for time coordinates is **`s since 1958-1-1`**.
 The reference datetime in the canonical unit (the beginning of the day i.e. midnight on 1st January 1958 at 0 `degrees_east`) is not restrictive; the time coordinate variable's own **`units`** may contain any reference datetime (after **`since`**) that is valid in its calendar.

--- a/ch03.adoc
+++ b/ch03.adoc
@@ -175,8 +175,6 @@ description:: The description is meant to clarify the qualifiers of the fundamen
 We don't attempt to provide precise definitions of fundumental physical quantities (e.g., temperature) which may be found in the literature.
 The description may define rules on the variable type, attributes and coordinates which must be complied with by any variable carrying that standard name (such as in Example 3.5).
 
-When appropriate, the table entry also contains the corresponding GRIB parameter code(s) (from ECMWF and NCEP) and AMIP identifiers.
-
 The standard name table is located at
 link:$$https://cfconventions.org/Data/cf-standard-names/current/src/cf-standard-name-table.xml$$[https://cfconventions.org/Data/cf-standard-names/current/src/cf-standard-name-table.xml],
 written in compliance with the XML format, as described in <<standard-name-table-format>>.

--- a/ch07.adoc
+++ b/ch07.adoc
@@ -41,7 +41,6 @@ A boundary variable inherits the values of some attributes from its parent coord
 If a coordinate variable has any of the attributes marked "BI" (for "inherit") in the "Use" column of <<attribute-appendix>>, they are assumed to apply to its bounds variable as well.
 It is recommended that BI attributes not be included on a boundary variable.
 If a BI attribute is included, it must also be present in the parent variable, and it must exactly match the parent attribute's data type and value.
-A boundary variable can only have inheritable attributes if they are also present on its parent coordinate variable.
 A bounds variable may have any of the attributes marked "BO" for ("own") in the "Use" column of <<attribute-appendix>>.
 These attributes take precedence over any corresponding attributes of the parent variable.
 In these cases, the parent variable's attribute does not apply to the bounds variable, regardless of whether the latter has its own attribute.

--- a/history.adoc
+++ b/history.adoc
@@ -7,6 +7,9 @@
 
 === Working version (most recent first)
 
+=== Version 1.12 (04 December 2023)
+
+* {issues}499[Issue #499]: Formatting of local links in text
 * {issues}566[Issue #566]: Fix invalid CRS WKT attribute in example 5.12.
 * {issues}527[Issue #527]: Clarify the conventions for boundary variables, especially for auxiliary coordinate variables of more than one dimension, state that there is no default for boundaries, add more information about bounds in section 1.
 * {issues}550[Issue #550]: Include a link to CF area-type table and make explicit the need to use standardized area-type strings in Section 7.3.3.

--- a/history.adoc
+++ b/history.adoc
@@ -7,7 +7,7 @@
 
 === Working version (most recent first)
 
-=== Version 1.12 (04 December 2023)
+=== Version 1.12 (04 December 2024)
 
 * {issues}499[Issue #499]: Formatting of local links in text
 * {issues}566[Issue #566]: Fix invalid CRS WKT attribute in example 5.12.

--- a/history.adoc
+++ b/history.adoc
@@ -5,10 +5,9 @@
 [[revhistory, Revision History]]
 == Revision History
 
-=== Working version (most recent first)
-
 === Version 1.12 (04 December 2024)
 
+* {issues}513[Issue #513]: Include DOI and License information in the conventions document 
 * {issues}499[Issue #499]: Formatting of local links in text
 * {issues}566[Issue #566]: Fix invalid CRS WKT attribute in example 5.12.
 * {issues}527[Issue #527]: Clarify the conventions for boundary variables, especially for auxiliary coordinate variables of more than one dimension, state that there is no default for boundaries, add more information about bounds in section 1.

--- a/toc-extra.adoc
+++ b/toc-extra.adoc
@@ -23,9 +23,9 @@ K.2. <<table-mesh-topology-attributes>>
 **List of Figures**
 
 [%hardbreaks]
+4.1. <<leap-second-timelines>>
 7.1. <<img-bnd_1d_coords>>
 7.2. <<img-bnd_2d_coords>>
-4.1. <<leap-second-timelines>>
 8.1. <<interpolation_subarea_generation>>
 8.2. <<ci_dimensions_overview>>
 8.3. <<ci_interpolation_parameters>>

--- a/version.adoc
+++ b/version.adoc
@@ -12,12 +12,12 @@ or with the commandline switch `-a final`.
 ifdef::final[]
 :current-version: {version}
 :current-version-as-attribute: {version}
-:doi: 10.5072/zenodo.FFFFFF
+:doi: 10.5281/zenodo.FFFFFF
 :doi-text: DOI: link:https://doi.org/{doi}[{doi}]
 endif::[]
 ifndef::final[]
 :current-version: {version} draft
 :current-version-as-attribute: {version}-draft
-:doi: 10.5072/zenodo.XXXXXX
+:doi: 10.5281/zenodo.FFFFFF
 :doi-text: has no DOI yet: link:https://doi.org/{doi}[{doi}]
 endif::[]

--- a/version.adoc
+++ b/version.adoc
@@ -9,11 +9,11 @@ or with the commandline switch `-a final`.
 // :final:
 
 ifdef::final[]
-:current-version: {version}
-:current-version-as-attribute: {version}
 // Change the DOI prior to releasing the next version
 :doi: 10.5281/zenodo.14275599
 // No changes needed beyond this line
+:current-version: {version}
+:current-version-as-attribute: {version}
 :doi-text: DOI: link:https://doi.org/{doi}[{doi}]
 endif::[]
 ifndef::final[]
@@ -22,4 +22,4 @@ ifndef::final[]
 :doi: 10.5281/zenodo.FFFFFF
 :doi-text: has no DOI yet: link:https://doi.org/{doi}[{doi}]
 endif::[]
-doi-link: https://doi.org/{doi}
+:doi-link: https://doi.org/{doi}

--- a/version.adoc
+++ b/version.adoc
@@ -8,11 +8,12 @@ or with the commandline switch `-a final`.
 ////
 // :final:
 
-// No changes needed beyond this line
 ifdef::final[]
 :current-version: {version}
 :current-version-as-attribute: {version}
-:doi: 10.5281/zenodo.FFFFFF
+// Change the DOI prior to releasing the next version
+:doi: 10.5281/zenodo.14275599
+// No changes needed beyond this line
 :doi-text: DOI: link:https://doi.org/{doi}[{doi}]
 endif::[]
 ifndef::final[]
@@ -21,3 +22,4 @@ ifndef::final[]
 :doi: 10.5281/zenodo.FFFFFF
 :doi-text: has no DOI yet: link:https://doi.org/{doi}[{doi}]
 endif::[]
+doi-link: https://doi.org/{doi}


### PR DESCRIPTION
No associated issue.

# Release checklist
- [x] Authors updated in `cf-conventions.adoc`? Add in two places: on line 3 and under `.Additional Authors` in `About the authors`.
- [x] Next version in `cf-conventions.adoc` up to date? Versioning inspired by [SemVer](https://semver.org).
- [x] `history.adoc` up to date?
- [x] Conformance document up to date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then, `main` always is a draft for the next version.
