### PR TITLE
Adding a dependabot yaml file to keep the workflows updated.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# See https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "Bot"
+    groups:
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
@sadielbartholomew: This was inspired by a commit you recently did to update an action.

I've added a dependabot file, which *should* automatically update the actions we are using for our publish workflow.

Nicer than having to go update those by hand.

I borrowed this from another project, so it *may* need some tweaking, but It should work as is.

When there is an update available, the dependabot creates a PR, which can then be merged.

NOTE: there don't seem to be any labels (or milestones) for this kind of infrastructure change .... maybe there should be?

@cf-convention/info-mgmt: pinging the team -- any one of you should be able to merge. 
