### PR TITLE
Allow explicit FINAL build date via CF_FINAL_DATE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,11 @@ REMOTE_URL=`git config remote.$TRACKING_REMOTE.url`
 FINAL_TAG ?= -a draft -a revnumber=v1.12.0-rc7-24-gb724218 -a revremark=${LOCAL_BRANCH}
 endif
 
+ifdef CF_FINAL_DATE
+DATE_DOCPROD != LC_ALL=C date -u -d "$(CF_FINAL_DATE)" "$(DATE_FORMAT)"
+else
 DATE_DOCPROD != LC_ALL=C date -u "$(DATE_FORMAT)"
+endif
 
 .PHONY: all clean images authors html pdf conventions-html conventions-pdf conventions conformance-html conformance-pdf conformance
 all: authors images html pdf 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ The following steps outline how to build the CF Conventions documentation into H
       `make conformance`
    - Remove built documents and clean build directories:
       `make clean`
-   - Build with the FINAL tag and a date stamp. Ensure you have manually updated the version in the `version.adoc` file before running this command:
-      `make CF_FINAL=True`
+   - Build with the FINAL tag and a date stamp. Ensure you have manually updated the version in the `version.adoc` file before running this command. For FINAL builds, the release date must be provided explicitly:
+      `make CF_FINAL=True CF_FINAL_DATE=YYYY-MM-DD`
 
 Both HTML documents will have images embedded within `.html` file.
 


### PR DESCRIPTION
See issue NONE for discussion of these changes.

# Release checklist
- [NA] `history.adoc` up to date?
- [NA] Conformance document up to date?

# For maintainers
After the merge remember to delete the source branch.
Tags are set at the conclusion of the annual meeting; until then, `main` always is a draft for the next version.
