### PR TITLE
Build toolchain and tests

### DIFF
--- a/.github/workflows/build_and_deploy_docs.yml
+++ b/.github/workflows/build_and_deploy_docs.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v4
   
       - name: APT Install Dependencies
-        run: sudo apt install -y python3-yaml asciidoctor ruby-asciidoctor-pdf
+        run: sudo apt install -y python3-yaml asciidoctor ruby-asciidoctor-pdf graphviz
 
       - name: Set Final Tag
         if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' && inputs.set_final_tag == 'true' }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ conformance.pdf
 conformance_build/
 build/
 .vscode/
+tests/
+.lycheecache

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,19 @@ CONF_DOC_BUILD_DIR := $(BUILD_DIR)
 
 CONF_DOC_INC := conformance.adoc version.adoc
 
+# ------------------------------------------------------------
+# Tools / commands (override from environment or CLI if needed)
+# ------------------------------------------------------------
+RUBY ?= ruby
+ASCIIDOCTOR ?= asciidoctor
+# Use `ruby -S` to locate the executable in a more portable way
+# (avoids issues with RubyGems-generated shebangs)
+#ASCIIDOCTOR_PDF ?= asciidoctor-pdf
+ASCIIDOCTOR_PDF ?= $(RUBY) -S asciidoctor-pdf
+PYTHON ?= python3
+DOT ?= dot
+# ------------------------------------------------------------
+
 ifdef CF_FINAL
 DATE_FORMAT := +%d&\#160;%B,&\#160;%Y
 FINAL_TAG := -a final
@@ -67,26 +80,26 @@ html: conventions-html conformance-html
 pdf: conventions-pdf conformance-pdf
 
 $(MAIN_DOC_BUILD_DIR)/$(MAIN_DOC).html: $(MAIN_DOC).adoc $(MAIN_DOC_INC) $(MAIN_DOC_IMG) | $(MAIN_DOC_BUILD_DIR)
-	asciidoctor --verbose --trace -a data-uri -a docprodtime="$(DATE_DOCPROD)" ${FINAL_TAG} $(MAIN_DOC).adoc -D $(MAIN_DOC_BUILD_DIR)
+	$(ASCIIDOCTOR) --verbose --trace -a data-uri -a docprodtime="$(DATE_DOCPROD)" ${FINAL_TAG} $(MAIN_DOC).adoc -D $(MAIN_DOC_BUILD_DIR)
 #	sed -E -i 's+(See&#160;)(https://cfconventions.org)(&#160;for&#160;further&#160;information.)+\1<a href="\2" target="_blank">\2</a>\3+' $(MAIN_DOC_BUILD_DIR)/$(MAIN_DOC).html
 
 $(MAIN_DOC_BUILD_DIR)/$(MAIN_DOC).pdf: $(MAIN_DOC).adoc $(MAIN_DOC_INC) $(MAIN_DOC_IMG) | $(MAIN_DOC_BUILD_DIR)
-	asciidoctor-pdf --verbose --trace -a docprodtime="$(DATE_DOCPROD)" ${FINAL_TAG} -d book -a pdf-theme=default-theme-CF-version.yml $(MAIN_DOC).adoc -D $(MAIN_DOC_BUILD_DIR)
+	$(ASCIIDOCTOR_PDF) --verbose --trace -a docprodtime="$(DATE_DOCPROD)" ${FINAL_TAG} -d book -a pdf-theme=default-theme-CF-version.yml $(MAIN_DOC).adoc -D $(MAIN_DOC_BUILD_DIR)
 
 $(CONF_DOC_BUILD_DIR)/$(CONF_DOC).html: $(CONF_DOC_INC) | $(CONF_DOC_BUILD_DIR)
-	asciidoctor --verbose --trace ${FINAL_TAG} $(CONF_DOC).adoc -D $(CONF_DOC_BUILD_DIR)
+	$(ASCIIDOCTOR) --verbose --trace ${FINAL_TAG} $(CONF_DOC).adoc -D $(CONF_DOC_BUILD_DIR)
 
 $(CONF_DOC_BUILD_DIR)/$(CONF_DOC).pdf: $(CONF_DOC_INC) | $(CONF_DOC_BUILD_DIR)
-	asciidoctor-pdf --verbose --trace ${FINAL_TAG} -d book $(CONF_DOC).adoc -D $(CONF_DOC_BUILD_DIR)
+	$(ASCIIDOCTOR_PDF) --verbose --trace ${FINAL_TAG} -d book $(CONF_DOC).adoc -D $(CONF_DOC_BUILD_DIR)
 
 about-authors.adoc: authors.adoc scripts/update_authors.py
-	python3 scripts/update_authors.py --authors-adoc=authors.adoc --write-about-authors=about-authors.adoc
+	$(PYTHON) scripts/update_authors.py --authors-adoc=authors.adoc --write-about-authors=about-authors.adoc
 
 zenodo.json: authors.adoc scripts/update_authors.py
-	python3 scripts/update_authors.py --authors-adoc=authors.adoc --update-zenodo=zenodo.json
+	$(PYTHON) scripts/update_authors.py --authors-adoc=authors.adoc --update-zenodo=zenodo.json
 
 CITATION.cff: authors.adoc scripts/update_authors.py
-	python3 scripts/update_authors.py --authors-adoc=authors.adoc --update-citation=CITATION.cff
+	$(PYTHON) scripts/update_authors.py --authors-adoc=authors.adoc --update-citation=CITATION.cff
   
 $(BUILD_DIR):
 	mkdir -vp $(BUILD_DIR)
@@ -96,13 +109,13 @@ clean:
 
 #Rules to build non-static images. See MAIN_DOC_IMG_BLD above
 images/cfdm_cf_concepts.svg: images/cfdm_cf_concepts.gv
-	dot -Tsvg $< -o $@
+	$(DOT) -Tsvg $< -o $@
 
 images/cfdm_coordinate_reference.svg: images/cfdm_coordinate_reference.gv
-	dot -Tsvg $< -o $@
+	$(DOT) -Tsvg $< -o $@
 
 images/cfdm_coordinates.svg: images/cfdm_coordinates.gv
-	dot -Tsvg $< -o $@
+	$(DOT) -Tsvg $< -o $@
 
 images/cfdm_field.svg: images/cfdm_field.gv
-	dot -Tsvg $< -o $@
+	$(DOT) -Tsvg $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ ASCIIDOCTOR_PDF ?= $(RUBY) -S asciidoctor-pdf
 PYTHON ?= python3
 DOT ?= dot
 # ------------------------------------------------------------
+# PDF theme used by asciidoctor-pdf
+PDF_THEME ?= default-theme-CF-version.yml
 
 ifdef CF_FINAL
 DATE_FORMAT := +%d&\#160;%B,&\#160;%Y
@@ -92,8 +94,8 @@ $(MAIN_DOC_BUILD_DIR)/$(MAIN_DOC).html: $(MAIN_DOC).adoc $(MAIN_DOC_INC) $(MAIN_
 	$(ASCIIDOCTOR) --verbose --trace -a data-uri -a docprodtime="$(DATE_DOCPROD)" ${FINAL_TAG} $(MAIN_DOC).adoc -D $(MAIN_DOC_BUILD_DIR)
 #	sed -E -i 's+(See&#160;)(https://cfconventions.org)(&#160;for&#160;further&#160;information.)+\1<a href="\2" target="_blank">\2</a>\3+' $(MAIN_DOC_BUILD_DIR)/$(MAIN_DOC).html
 
-$(MAIN_DOC_BUILD_DIR)/$(MAIN_DOC).pdf: default-theme-CF-version.yml $(MAIN_DOC).adoc $(MAIN_DOC_INC) $(MAIN_DOC_IMG) | $(MAIN_DOC_BUILD_DIR)
-	$(ASCIIDOCTOR_PDF) --verbose --trace -a docprodtime="$(DATE_DOCPROD)" ${FINAL_TAG} -d book -a pdf-theme=default-theme-CF-version.yml $(MAIN_DOC).adoc -D $(MAIN_DOC_BUILD_DIR)
+$(MAIN_DOC_BUILD_DIR)/$(MAIN_DOC).pdf: $(PDF_THEME) $(MAIN_DOC).adoc $(MAIN_DOC_INC) $(MAIN_DOC_IMG) | $(MAIN_DOC_BUILD_DIR)
+	$(ASCIIDOCTOR_PDF) --verbose --trace -a docprodtime="$(DATE_DOCPROD)" ${FINAL_TAG} -d book -a pdf-theme=$(PDF_THEME) $(MAIN_DOC).adoc -D $(MAIN_DOC_BUILD_DIR)
 
 $(CONF_DOC_BUILD_DIR)/$(CONF_DOC).html: $(CONF_DOC_INC) | $(CONF_DOC_BUILD_DIR)
 	$(ASCIIDOCTOR) --verbose --trace ${FINAL_TAG} $(CONF_DOC).adoc -D $(CONF_DOC_BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -127,18 +127,8 @@ clean:
 	rm -rvf $(BUILD_DIR)
 
 #Rules to build non-static images. See MAIN_DOC_IMG_BLD above
-images/cfdm_cf_concepts.svg: images/cfdm_cf_concepts.gv
+images/%.svg: images/%.gv
 	$(DOT) -Tsvg $< -o $@
-
-images/cfdm_coordinate_reference.svg: images/cfdm_coordinate_reference.gv
-	$(DOT) -Tsvg $< -o $@
-
-images/cfdm_coordinates.svg: images/cfdm_coordinates.gv
-	$(DOT) -Tsvg $< -o $@
-
-images/cfdm_field.svg: images/cfdm_field.gv
-	$(DOT) -Tsvg $< -o $@
-
 # ------------------------------------------------------------
 
 # Tests

--- a/README.md
+++ b/README.md
@@ -49,6 +49,38 @@ Ensure the built documents meet your requirements before publishing.
 
 See the [GitHub help](https://help.github.com/) pages and many other git/GitHub guides for more details on how to work with repos, forks, pull requests, etc.
 
+## Testing
+
+A basic link checker is available to validate external and internal (i.e. *fragments*) links in the generated HTML documents.
+
+To run the link check:
+  - `make test-links`
+
+This updates the HTML documents and runs `lychee` on the generated `build/cf-conventions.html` and `build/conformance.html`.
+
+A report, for both files, is written in the `tests/lychee.md` Markdown file.
+
+The command fails if broken links are detected.
+
+## Optional: reproducible build environment
+
+For convenience, a minimal `environment.yml` is provided to create a reproducible
+documentation build environment using `conda`/`mamba` from the `conda-forge`
+channel.
+
+This is optional and system packages (i.e. `apt`) or `RubyGems` can also be used.
+
+To create and activate the environment:
+  - `conda env create -f environment.yml`
+  - `conda activate cf-conventions-docs`
+
+However, `asciidoctor-pdf` is not available via `conda-forge`, and must be
+installed via RubyGems in the activated environment:
+  - `gem install asciidoctor-pdf`
+
+The `Makefile` checks for the required tools at build time and reports clear
+errors if any dependency is missing.
+
 ## Latest Spec Build
 
 Whenever a [pull request](https://github.com/cf-convention/cf-conventions/pulls) is merged, a [travis-ci build](https://travis-ci.org/github/cf-convention/cf-conventions) generates the latest specification draft and adds it to the [gh-pages branch here](https://github.com/cf-convention/cf-conventions/tree/gh-pages).

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ The CF Conventions are changed by changing the source files in this repository.
 The rules for doing this are set forth on the [CF website](https://cfconventions.org/rules.html).
 Their implementation in GitHub is described in this repository's [CONTRIBUTING.md file](https://github.com/cf-convention/cf-conventions/blob/master/CONTRIBUTING.md).
 
-# Building the HTML
+# Building the documentation
 
-The following steps outline how to build the CF Conventions documentation into HTML and/or PDF format using AsciiDoc:
+The following steps outline how to build the CF Conventions documentation into HTML and/or PDF format using AsciiDoc and the provided Makefile:
 
 1. Ensure you have [Ruby](https://www.ruby-lang.org/) installed. (e.g. `sudo apt install ruby`)
 2. Ensure you have a recent version of [Asciidoctor](https://asciidoctor.org/) installed (e.g. `gem install asciidoctor`)
@@ -34,8 +34,6 @@ The following steps outline how to build the CF Conventions documentation into H
       `make conformance`
    - Remove built documents and clean build directories:
       `make clean`
-   - Build with the FINAL tag and a date stamp. Ensure you have manually updated the version in the `version.adoc` file before running this command. For FINAL builds, the release date must be provided explicitly:
-      `make CF_FINAL=True CF_FINAL_DATE=YYYY-MM-DD`
 
 Both HTML documents will have images embedded within `.html` file.
 
@@ -48,6 +46,47 @@ The built documents will be rendered in the `build` directory with the resulting
 Ensure the built documents meet your requirements before publishing.
 
 See the [GitHub help](https://help.github.com/) pages and many other git/GitHub guides for more details on how to work with repos, forks, pull requests, etc.
+
+## Release metadata
+
+The file `version.adoc` acts as the single source of truth for the CF version number, canonical release date, and DOI. In particular, the following attributes are edited manually at the start of each new release
+cycle:
+
+- `version`
+- `release-date-iso`
+- `doi`
+
+All other release-related attributes (such as the human-readable display date or the citation year) are either derived from these values or injected by the build system (Makefile/CI). For ad-hoc local builds without the Makefile, sensible fallbacks are provided so that the document still renders consistently.
+
+## Build modes (DRAFT vs FINAL)
+
+By default, builds are produced in **DRAFT** mode, which is what you get from a normal call to `make`:
+
+~~~bash
+make
+~~~
+
+To produce a build intended for publication as an **official FINAL release**, set the environment variable `DOC_STATUS` to `FINAL`:
+
+~~~bash
+DOC_STATUS=FINAL make
+~~~
+
+In FINAL mode:
+
+- the visible release date is derived from `release-date-iso`
+- the citation year used in the formal citation is fixed from the canonical release date
+- timestamps and other draft-only metadata are not shown
+
+### Advanced: Overriding the release date
+
+Normally you should not need to override the `release-date-iso` attribute. However, for testing or exceptional cases you may explicitly set the environment variable `RELEASE_DATE_ISO` when building in `FINAL` document status:
+
+~~~bash
+DOC_STATUS=FINAL RELEASE_DATE_ISO="2026-02-16" make
+~~~
+
+Environment-provided values always take precedence over the defaults derived by the `Makefile`.
 
 ## Testing
 

--- a/cf-conventions.adoc
+++ b/cf-conventions.adoc
@@ -1,8 +1,6 @@
 include::version.adoc[]
 include::authors.adoc[]
 = NetCDF Climate and Forecast (CF) Metadata Conventions
-:revnumber: {current-version}
-:revdate: {docprodtime}
 :doctype: book
 :pdf-folio-placement: physical
 :sectanchors:

--- a/cf-conventions.adoc
+++ b/cf-conventions.adoc
@@ -16,18 +16,10 @@ image:images/cc-zero.svg[,9%,pdfwidth=50vw]
 This document is dedicated to the public domain following the link:https://creativecommons.org/publicdomain/zero/1.0/[Creative Commons Zero v1.0 Universal] Deed.
 
 The Climate and Forecasting Conventions website https://cfconventions.org/ contains additional resources and provides further information.
-ifdef::final[]
- +
- +
- _Use the following reference to cite this version of the document:_ +
+{empty} +
+{empty} +
+_{citability-note}_ +
 Eaton, B., Gregory, J., Drach, B., Taylor, K., Hankin, S. et al. ({docyear}). NetCDF Climate and Forecast (CF) Metadata Conventions ({current-version-as-attribute}). CF Community. {doi-link}
-endif::[]
-ifndef::final[]
- +
- +
- _DON’T use the following reference to cite this version of the document, as it is only shown as a draft:_ +
-Eaton, B., Gregory, J., Drach, B., Taylor, K., Hankin, S. et al. ({docyear}). NetCDF Climate and Forecast (CF) Metadata Conventions ({current-version-as-attribute}). CF Community. {doi-link}
-endif::[]
 
 '''
 

--- a/cf-conventions.adoc
+++ b/cf-conventions.adoc
@@ -17,7 +17,7 @@ The Climate and Forecasting Conventions website https://cfconventions.org/ conta
 {empty} +
 {empty} +
 _{citability-note}_ +
-Eaton, B., Gregory, J., Drach, B., Taylor, K., Hankin, S. et al. ({docyear}). NetCDF Climate and Forecast (CF) Metadata Conventions ({current-version-as-attribute}). CF Community. {doi-link}
+Eaton, B., Gregory, J., Drach, B., Taylor, K., Hankin, S. et al. ({release-date-year}). NetCDF Climate and Forecast (CF) Metadata Conventions ({current-version-as-attribute}). CF Community. {doi-link}
 
 '''
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,14 @@
+name: cf-conventions-docs
+
+channels:
+  - conda-forge          # Main channel used for reproducible builds
+
+dependencies:
+  - make                 # Entry point for the documentation build workflow
+  - ruby=3.1             # Ruby runtime required by Asciidoctor
+  - asciidoctor=2.0      # Core tool to build the CF documentation from AsciiDoc
+  - graphviz             # Used to generate SVG figures from .gv files (dot)
+  - python=3             # Required to run helper scripts (Python 3)
+  - pyyaml               # Used by scripts/update_authors.py to update
+                         # zenodo.json and CITATION.cff
+                      

--- a/environment.yml
+++ b/environment.yml
@@ -11,4 +11,5 @@ dependencies:
   - python=3             # Required to run helper scripts (Python 3)
   - pyyaml               # Used by scripts/update_authors.py to update
                          # zenodo.json and CITATION.cff
+  - lychee               # Link checker used to validate hyperlinks in the docs
                       

--- a/version.adoc
+++ b/version.adoc
@@ -15,11 +15,18 @@ ifdef::final[]
 :current-version: {version}
 :current-version-as-attribute: {version}
 :doi-text: DOI: link:https://doi.org/{doi}[{doi}]
+:citability-note: Use the following reference to cite this version of the document:
 endif::[]
 ifndef::final[]
 :current-version: {version} draft
 :current-version-as-attribute: {version}-draft
 :doi: 10.5281/zenodo.FFFFFF
 :doi-text: has no DOI yet: link:https://doi.org/{doi}[{doi}]
+:citability-note: DON’T use the following reference to cite this version of the document, as it is only shown as a draft:
 endif::[]
 :doi-link: https://doi.org/{doi}
+
+// NOTE: This attribute is intentionally empty.
+// It is used to anchor '+' line continuations in a robust way when composing
+// multi-line paragraphs with attribute substitutions.
+:empty:

--- a/version.adoc
+++ b/version.adoc
@@ -1,36 +1,109 @@
-// Set version
+// -----------------------------------------------------------------------------
+// Primary release identifiers (manual inputs)
+// -----------------------------------------------------------------------------
+//
+// These three attributes are the *only* values that must be edited manually
+// when starting the publication process for a new CF version:
+//
+//   - version           CF version number
+//   - release-date-iso  canonical release date (ISO 8601)
+//   - doi               DOI assigned to this CF version
+//
+// All other release-related attributes (textual date, citation year, etc.)
+// are derived from these or injected by the build system (Makefile/CI).
+//
 :version: 1.14
 
-////
-Normally, a draft is produced, unless the `final` attribute is defined.
-Define the `final` attribute by uncommenting the following line
-or with the commandline switch `-a final`.
-////
-// :final:
+// Canonical release date for this CF version (ISO 8601).
+// This is the single source of truth for the official release date and is
+// also used as the publication date in external metadata (e.g. Zenodo).
+:release-date-iso: 2026-02-15
 
-ifdef::final[]
-// Change the DOI prior to releasing the next version
+// DOI assigned to this CF version.
+// IMPORTANT: update `version`, `release-date-iso` and `doi` together at the
+// start of each new release cycle.
 :doi: 10.5281/zenodo.17801666
-// No changes needed beyond this line
-:current-version: {version}
-:current-version-as-attribute: {version}
-:doi-text: DOI: link:https://doi.org/{doi}[{doi}]
-:citability-note: Use the following reference to cite this version of the document:
-endif::[]
-ifndef::final[]
-:current-version: {version} draft
-:current-version-as-attribute: {version}-draft
-:doi: 10.5281/zenodo.FFFFFF
-:doi-text: has no DOI yet: link:https://doi.org/{doi}[{doi}]
-:citability-note: DON’T use the following reference to cite this version of the document, as it is only shown as a draft:
-endif::[]
+
+// -----------------------------------------------------------------------------
+// Derived release and editorial metadata
+// -----------------------------------------------------------------------------
+//
+// The build system normally derives and injects these attributes based on
+// the primary identifiers above and the editorial status (FINAL / DRAFT / RC).
+// For standalone Asciidoctor builds (without the Makefile), we provide safe
+// fallbacks so the document still renders consistently.
+//
+
+// Human-readable text form of the release date shown in the document
+// (e.g. "15 February 2026").
+// Normally injected by the build system as `release-date-text`.
+// Fallback: use the canonical ISO value.
+ifndef::release-date-text[:release-date-text: {release-date-iso}]
+
+// Year used in the formal citation.
+// FINAL builds: injected from `release-date-iso` by the build system.
+// Other builds or standalone Asciidoctor: fall back to Asciidoctor's `docyear`.
+ifndef::release-date-year[:release-date-year: {docyear}]
+
+// Editorial status of this document from the CF perspective.
+// Expected values include:
+//
+//   DRAFT  - working draft, not an official release
+//   FINAL  - official, published CF release
+//   RC     - release candidate
+//
+// The build system typically sets this via DOC_STATUS.
+// For standalone builds we default to DRAFT so the document is clearly
+// marked as non-final and all conditional logic remains well-defined.
+ifndef::doc-status[:doc-status: DRAFT]
+
+// -----------------------------------------------------------------------------
+// Build metadata contract (inputs)
+// -----------------------------------------------------------------------------
+//
+// The following attributes are normally injected by the build system
+// (Makefile/CI) to capture build provenance. They are not part of the CF
+// specification itself. For standalone Asciidoctor builds, we supply safe
+// defaults so they are always defined.
+//
+
+ifndef::build-context[:build-context: LOCAL]
+ifndef::build-ref[:build-ref: UNKNOWN]
+ifndef::build-repository[:build-repository: UNKNOWN]
+ifndef::build-revision[:build-revision: UNKNOWN]
+
+// For standalone builds use Asciidoctor's docdatetime as a proxy
+// for the build timestamp.
+ifndef::build-timestamp[:build-timestamp: {docdatetime}]
+
+// -----------------------------------------------------------------------------
+// Editorial state (FINAL vs DRAFT)
+// -----------------------------------------------------------------------------
 :doi-link: https://doi.org/{doi}
 
-// NOTE: This attribute is intentionally empty.
-// It is used to anchor '+' line continuations in a robust way when composing
-// multi-line paragraphs with attribute substitutions.
-:empty:
+ifeval::["{doc-status}" == "FINAL"]
+// FINAL builds: keep release metadata stable and human-facing.
+:current-version: {version}
+:current-version-as-attribute: {version}
+:doi-text: link:{doi-link}[{doi}]
+:citability-note: Use the following reference to cite this version of the document:
 
-// Set revision info
+// Revision line (Asciidoctor): show the stable release date; keep remark empty.
 :revnumber: {current-version}
-:revdate: {docprodtime}
+:revdate: {release-date-text}
+endif::[]
+
+ifeval::["{doc-status}" != "FINAL"]
+// DRAFT builds: include build provenance and discourage citation.
+:current-version: {version} draft
+:current-version-as-attribute: {version}-draft
+:doi-text: has no DOI yet: link:{doi-link}[{doi}]
+:citability-note: DON’T use the following reference to cite this version of the document, as it is only shown as a draft:
+
+// Revision line (Asciidoctor): preserve visible date style via docprodtime.
+:revnumber: {current-version}
+:revdate: {build-timestamp}
+// Compose provenance: <context>:<repository>@<ref> (<revision>)
+:revremark: {build-context}:{build-repository}@{build-ref}{empty}({build-revision})
+endif::[]
+// -----------------------------------------------------------------------------

--- a/version.adoc
+++ b/version.adoc
@@ -30,3 +30,7 @@ endif::[]
 // It is used to anchor '+' line continuations in a robust way when composing
 // multi-line paragraphs with attribute substitutions.
 :empty:
+
+// Set revision info
+:revnumber: {current-version}
+:revdate: {docprodtime}

--- a/zenodo.json
+++ b/zenodo.json
@@ -209,12 +209,12 @@
   "files": [
     {
       "filename": "cf-conventions.pdf",
-      "size": 6978931
+      "size": 6978931,
       "checksum": "md5:191dd3a3b52c3cf1a168b968ed197c22"
     },
     {
       "filename": "conformance.pdf",
-      "size": 433779
+      "size": 433779,
       "checksum": "md5:3dd55e78fbdbe668e8b1b2bafc562011"
     }
   ]


### PR DESCRIPTION
No issue associated: this PR contains incremental tooling and documentation build improvements.  There are no changes to the CF specification content.

### Summary of changes

This PR improves the documentation build workflow and metadata plumbing:

- Refactors the `Makefile` to make tool invocation more robust and *overridable*.
- Adds explicit tool checks with clear error messages.
- Introduces an optional `environment.yml` for reproducible Conda/Mamba builds.
- Adds a basic link checker (`make test-links`) using `lychee`.
- Updates `README.md` to document the build workflow.
- Centralises release metadata in `version.adoc`, which now acts as the single source of truth for:
  - CF version number
  - canonical ISO release date
  - DOI (no yet defined)
- Wires this metadata into the build system so that `DRAFT` and `FINAL` builds are explicit and reproducible.

All changes are optional and backward-compatible. System packages (apt) and RubyGems remain supported.  
No changes are made to the normative text.

---

## Current behaviour

- A normal `make` build produces a DRAFT document.
- A FINAL build may be produced using:

```bash
DOC_STATUS=FINAL make
```

In FINAL mode:

- the visible release date is derived from the canonical `release-date-iso`
- the citation year is fixed from the canonical release date
- draft-only metadata is suppressed

This ensures that FINAL releases are fully reproducible.

---

## Out of scope for this PR

This PR does not yet define:

- the complete CF release workflow (DRAFT to RC to FINAL)
- branch or tag conventions
- formal release governance

The intention is to keep this PR focused on safe, incremental build improvements.

A separate Discussion will be opened with the Information Management Team in order to agree collaboratively on:

- the editorial states to support
- the Git branching and tagging model
- a shared release checklist

Once there is consensus, a follow-up PR can implement the agreed workflow.

---

# Release checklist

```
[NA] history.adoc up to date?
[NA] Conformance document up to date?
```

---

# For maintainers

After merge:

- delete the source branch when convenient
- tags are set at the conclusion of the annual meeting
- `main` continues to represent a working draft for the next version