### PR TITLE
Create dormant-issues.yaml

### DIFF
--- a/.github/workflows/dormant-issues.yaml
+++ b/.github/workflows/dormant-issues.yaml
@@ -1,0 +1,35 @@
+name: Mark and Close Dormant Issues
+
+on:
+  schedule:
+    - cron: "0 2 * * *" # daily
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # 6 months ≈ 180 days
+          days-before-stale: 180
+          # 3 weeks = 21 days
+          days-before-close: 21
+
+          stale-issue-label: "inactive"
+          close-issue-label: "dormant"
+
+          stale-issue-message: >
+            This issue has been inactive for 6 months.
+            It will be closed as dormant in 3 weeks if no further activity occurs.
+
+          close-issue-message: >
+            Closing this issue as dormant due to continued inactivity.
+
+          # Optional but recommended
+          #exempt-issue-labels: 
+          operations-per-run: 100
+          remove-stale-when-updated: true
+          only-issues: true

--- a/.github/workflows/dormant-issues.yaml
+++ b/.github/workflows/dormant-issues.yaml
@@ -26,7 +26,7 @@ jobs:
             It will be closed as dormant in 3 weeks if no further activity occurs.
 
           close-issue-message: >
-            Closing this issue as dormant due to continued inactivity.
+            This issue was closed as dormant because of inactivity for more than six months. Anyone can reopen it to resume the discussion.
 
           # Optional but recommended
           #exempt-issue-labels: 


### PR DESCRIPTION
As per email request from Jonathan G

> Do you think GitHub actions could automate this procedure:
> >
> > * If no contributions for six months, add a contribution to say it'll be closed as dormant in three weeks if no-one posts to continue it.
> >
> > * If still no contributions within three weeks, attach the "dormant" label to it and close the issue.

After 6 months this adds a label 'inactive' so if activity occurs then label is removed. If no further activity in 3 weeks then closes with dormant label.
