### PR TITLE
Create closed-issues.yaml

### DIFF
--- a/.github/workflows/closed-issues.yaml
+++ b/.github/workflows/closed-issues.yaml
@@ -1,0 +1,22 @@
+name: Remove inactive label on close
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  remove-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove inactive label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.issue.labels.map(l => l.name);
+            if (labels.includes('inactive')) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                name: 'inactive'
+              });
+            }


### PR DESCRIPTION
Following on from the GitHub action that was added for stale issues. This workflow simply looks at issues when they are closed and removes the 'inactive' label as it's no longer needed. These issues are closed with the 'dormant' issue label. Jonathan G has asked for this change.